### PR TITLE
Launch AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ docker-compose pull
 docker-compose up -d
 ```
 
+### Remote Demo Mode (AWS)
+Make sure the AWS CLI is installed and configured with your credentials, and you have a VPC in which to deploy the instances.
+```
+export AWS_VPC_ID=your-vpc-id
+export AWS_REGION=your-region
+#export AWS_INSTANCE_ZONE=region-zone (defaults to a)
+#export AWS_INSTANCE_TYPE=instance-type (defaults to t2.medium)
+./scripts/install.sh launch-aws
+eval $(docker-machine env --swarm swarm-master)
+docker-compose pull
+docker-compose up -d
+```
+
 ### Remote Demo Mode
 Setup the remote machines with docker, swarm, weave net and scope. Then:
 ```

--- a/load-test/runLocust.sh
+++ b/load-test/runLocust.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Run locust load test
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Install docker-machine cluster, swarm, weave and scope
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,12 +13,12 @@ do_checks() {
   # check for docker-machine
   if [ ! `command -v docker-machine` ]; then
     echo "Docker Machine is not found!"
-    exit 0
+    exit 1
   fi
   # check for docker
   if [ ! `command -v docker` ]; then
     echo "Docker is not found!"
-    exit 0
+    exit 1
   fi
 }
 do_launch() {
@@ -32,6 +32,13 @@ do_launch() {
       echo "Creating docker-machines and installing swarm on AWS"
       $SCRIPT_DIR/installSwarm.sh create 2 amazonec2
   esac
+
+  # Abort launch if swarm create failed
+  if [ $? -ne 0 ]
+  then
+    echo "Error in upstream script"
+    exit 1
+  fi
 
   echo "Installing weave"
   $SCRIPT_DIR/installWeave.sh launch

--- a/scripts/installScope.sh
+++ b/scripts/installScope.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Launch Scope correctly on all Docker Machines in the Swarm
 #

--- a/scripts/installSwarm.sh
+++ b/scripts/installSwarm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh +x
+#!/bin/bash +x
 #
 # Handy utility for creating a Swarm environment using Docker Machine
 #

--- a/scripts/installSwarm.sh
+++ b/scripts/installSwarm.sh
@@ -9,40 +9,56 @@ DRIVER="${3:-virtualbox}"
 do_checks() {
   if [ ! `command -v docker-machine` ]; then
     echo "Docker Machine is not found!"
-    exit 0
+    exit 1
   fi
   # check for docker
   if [ ! `command -v docker` ]; then
     echo "Docker is not found!"
-    exit 0
+    exit 1
   fi
-  return 1
 }
 do_create() {
   do_checks
   KEYSTORE_NAME=`docker-machine ls --format="{{.Name}}" --filter="name=swarm-keystore"`
 
-  if [ "$DRIVER" == "AWS" ]; then
+  if [ "$DRIVER" = "amazonec2" ]; then
+    # shelling out to external bins, make sure we fail the script if one of the commands fails
+    set -e
     echo "Installing Swarm on AWS..."
     if [ ! `command -v aws` ]; then
       echo "AWS command line tools not found."
-      exit 0
+      exit 1
     fi
 
-    #Set up Security Group in AWS
+    if [[ -z $AWS_VPC_ID || -z $AWS_REGION ]]
+    then
+      echo "ERROR: At least one of AWS_VPC_ID or AWS_REGION is missing"
+      echo "Use:" 
+      echo "     export AWS_VPC_ID=your-vpc-id"
+      echo "     export AWS_REGION=your-region"
+      echo ""
+      echo "prior to launching the installation"
+      echo  ""
+      exit 1
+    fi
 
-    group_name="docker-networking"
-    aws ec2 create-security-group --group-name ${group_name} --description "A Security Group for Docker Networking"
-    # Permit SSH, required for Docker Machine
-    aws ec2 authorize-security-group-ingress --group-name ${group_name} --protocol tcp --port 22 --cidr 0.0.0.0/0
-    aws ec2 authorize-security-group-ingress --group-name ${group_name} --protocol tcp --port 2376 --cidr 0.0.0.0/0
-    # Permit Consul HTTP API
-    aws ec2 authorize-security-group-ingress --group-name ${group_name} --protocol tcp --port 8500 --cidr 0.0.0.0/0
-    # Weave 
-    aws ec2 authorize-security-group-ingress --group-name ${group_name} --protocol tcp --port 6783 --cidr 0.0.0.0/0
-    aws ec2 authorize-security-group-ingress --group-name ${group_name} --protocol udp --port 6783 --cidr 0.0.0.0/0
+    #Set up Security Group in AWS if not created
+    if [[ -z $(aws ec2 describe-security-groups --filter "Name=group-name,Values=docker-swarm" --output text) ]]
+    then
+      echo "Creating security group \"docker-swarm\"..."
+      group_name=$(aws ec2 create-security-group --group-name docker-swarm --vpc-id $AWS_VPC_ID --description "An Example Security Group for Docker Networking" --output text)
 
-    CREATE_ARGS="--driver amazonec2 --amazonec2-instance-type=t2.medium --amazonec2-vpc-id=vpc-a7d209c0 --amazonec2-zone=d --amazonec2-security-group ${group_name}"
+      # Permit SSH, required for Docker Machine
+      aws ec2 authorize-security-group-ingress --group-id ${group_name} --protocol tcp --port 22 --cidr 0.0.0.0/0
+      aws ec2 authorize-security-group-ingress --group-id ${group_name} --protocol tcp --port 2376 --cidr 0.0.0.0/0
+      # Permit Consul HTTP API
+      aws ec2 authorize-security-group-ingress --group-id ${group_name} --protocol tcp --port 8500 --cidr 0.0.0.0/0
+      # Weave 
+      aws ec2 authorize-security-group-ingress --group-id ${group_name} --protocol tcp --port 6783 --cidr 0.0.0.0/0
+      aws ec2 authorize-security-group-ingress --group-id ${group_name} --protocol udp --port 6783 --cidr 0.0.0.0/0
+    fi
+
+    CREATE_ARGS="--driver amazonec2 --amazonec2-instance-type=${AWS_INSTANCE_TYPE:-t2.medium} --amazonec2-vpc-id=$AWS_VPC_ID --amazonec2-region=$AWS_REGION --amazonec2-zone=${AWS_INSTANCE_ZONE:-a} --amazonec2-security-group docker-swarm"
     ETHERNET="eth0"
   else
     CREATE_ARGS="--driver virtualbox"
@@ -63,7 +79,7 @@ do_create() {
     RET="${RET#Server Version: }"
     if [ -z "$RET" ]; then
       echo "'docker info' returned an error"
-      exit 0
+      exit 1
     fi
   fi
   # Launch an Hashicorp Consul key/value store instance.
@@ -94,7 +110,6 @@ do_create() {
   RET=`docker info | grep -m1 -o 'Server Version: .*' `
   RET="${RET#Server Version: }"
   eval "$(docker-machine env --swarm swarm-master)"
-  exit 1
 }
 do_add() {
   do_checks
@@ -130,7 +145,6 @@ do_add() {
   done
   # Output the current state of the Swarm
   docker-machine ls --filter="swarm=swarm-master"
-  exit 1
 }
 do_destroy() {
   SWARM=`docker-machine ls --filter="swarm=swarm-master" --format="{{.Name}}"`
@@ -141,7 +155,6 @@ do_destroy() {
   done
   echo "Removing swarm-keystore..."
   docker-machine stop swarm-keystore && docker-machine rm -y swarm-keystore
-  exit 0
 }
 do_list() {
   do_checks
@@ -158,7 +171,6 @@ do_list() {
   LIST=`docker run swarm list consul://${KEYSTORE_IP}:8500`
   echo "$LIST"
 
-  exit 1
 }
 do_usage() {
   cat >&2 <<EOF

--- a/scripts/installWeave.sh
+++ b/scripts/installWeave.sh
@@ -1,4 +1,4 @@
-#!/bin/sh +x
+#!/bin/bash +x
 #
 # Quickly launch Weave correctly on a Docker Swarm
 #

--- a/scripts/scope
+++ b/scripts/scope
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 

--- a/scripts/weave
+++ b/scripts/weave
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 [ -n "$WEAVE_DEBUG" ] && set -x
@@ -128,7 +128,7 @@ cni_volume_options() {
 
 create_cni_script() {
     cat >"$1" <<EOF
-#!/bin/sh
+#!/bin/bash
 docker run --rm $(docker_run_options) --pid=host -i \\
  -e CNI_VERSION -e CNI_COMMAND -e CNI_CONTAINERID -e CNI_NETNS \\
  -e CNI_IFNAME -e CNI_ARGS -e CNI_PATH $(cni_volume_options setup) \\


### PR DESCRIPTION
I've made a couple of changes to allow launching the weaveDemo on AWS. AWS environments have now been parameterised so users can choose a VPC to launch into, and I fixed/removed a few of the exit statements in the various functions. README has been updated to include instructions of how to launch into AWS.

Also targeted `/bin/bash` directly for the build scripts. `/bin/sh` points at `/bin/dash` on Ubuntu and the scripts were failing with syntax errors.
