### PR TITLE
docs: update broken links in docker-single

### DIFF
--- a/deploy/docker-single/README.md
+++ b/deploy/docker-single/README.md
@@ -5,8 +5,8 @@ The Weave Demo application is packaged using a [Docker Compose](https://docs.doc
 ## Pre-requisites
 
 - Install Docker
-- Install [Weave Net](https://www.weave.works/products/install-weave-net/)
-- Install [Weave Scope](https://www.weave.works/products/install-weave-scope/)
+- Install [Weave Net](https://www.weave.works/install-weave-net/)
+- Install [Weave Scope](https://www.weave.works/install-weave-scope/)
 
 ## Install & run
 


### PR DESCRIPTION
This fixes 2 broken links to install instructions in the docker-single README. 
