### PR TITLE
docs: include 'weave launch' step in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cd deploy/docker-single
 docker-machine create default -d virtualbox
 eval $(docker-machine env default)
 docker-compose pull
+weave launch
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Adds a `weave launch` step to the [Non-swarm mode, local virtual machine](https://github.com/weaveworks/weaveDemo#non-swarm-mode-local-virtual-machine) section of the main README.

This step is included in the [`docker-single` directory's readme](https://github.com/weaveworks/weaveDemo/tree/master/deploy/docker-single) but not in the main README.

I haven't tested the other deploys yet, could be same for those.
