### PR TITLE
Update repository URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please open an issue if you have found an issue or have an idea for a new featur
 
 ## New Contributors
 
-We have a list of issues on Github with "HelpWanted" labels attributed to them. These represent tasks that we don't have time to do, are self-contained and relatively easy to implement. If you'd like to contribute, but don't know where to start, [look here](https://github.com/weaveworks/microservices-demo/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AHelpWanted).
+We have a list of issues on Github with "HelpWanted" labels attributed to them. These represent tasks that we don't have time to do, are self-contained and relatively easy to implement. If you'd like to contribute, but don't know where to start, [look here](https://github.com/microservices-demo/microservices-demo/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AHelpWanted).
 
 ## Direction
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/weaveworks/microservices-demo.svg?branch=master)](https://travis-ci.org/weaveworks/microservices-demo)
+[![Build Status](https://travis-ci.org/microservices-demo/microservices-demo.svg?branch=master)](https://travis-ci.org/microservices-demo/microservices-demo)
 
 # Sock Shop : A Microservice Demo Application
 

--- a/deploy/docker-only/README.md
+++ b/deploy/docker-only/README.md
@@ -9,7 +9,7 @@ The Weave Demo application is packaged using a [Docker Compose](https://docs.doc
 
 ## Install & run
 
-    curl -L https://raw.githubusercontent.com/weaveworks/weaveDemo/master/deploy/docker-only/docker-compose.yml -o docker-compose.yml
+    curl -L https://raw.githubusercontent.com/microservices-demo/microservices-demo/master/deploy/docker-only/docker-compose.yml -o docker-compose.yml
     docker-compose up -d
 
 ## Launch Weave Scope or Weave Cloud

--- a/deploy/docker-single/README.md
+++ b/deploy/docker-single/README.md
@@ -11,7 +11,7 @@ The Weave Demo application is packaged using a [Docker Compose](https://docs.doc
 ## Install & run
 
     weave launch
-    curl -L https://raw.githubusercontent.com/weaveworks/weaveDemo/master/deploy/docker-single/docker-compose.yml -o docker-compose.yml
+    curl -L https://raw.githubusercontent.com/microservices-demo/microservices-demo/master/deploy/docker-single/docker-compose.yml -o docker-compose.yml
     docker-compose up -d
 
 ## Launch Weave Scope or Weave Cloud

--- a/deploy/docker-swarm/README.md
+++ b/deploy/docker-swarm/README.md
@@ -12,7 +12,7 @@ The Weave Demo application is packaged using a [Docker Compose](https://docs.doc
 
 Launch Weave Net on each host. There are [instructions for preparing a Swarm](../../install/docker-machine-swarm) specific to this demo.
 
-    curl -L https://raw.githubusercontent.com/weaveworks/weaveDemo/master/deploy/docker-swarm/docker-compose.yml -o docker-compose.yml
+    curl -L https://raw.githubusercontent.com/microservices-demo/microservices-demo/master/deploy/docker-swarm/docker-compose.yml -o docker-compose.yml
     docker-compose up -d
 
 ## Launch Weave Cloud

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,12 +1,12 @@
 #Setup and Installation on Kubernetes
 
-(If you already have running k8s cluster skip to [here](https://github.com/weaveworks/weaveDemo/tree/kubernetes/kubernetes#deploy-app))
+(If you already have running k8s cluster skip to [here](#deploy-app))
 
 Setup up Kubernetes cluster on AWS using [kubernetes-anywhere](https://github.com/kubernetes/kubernetes-anywhere) (with Terraform)
 
 ```
-git clone https://github.com/weaveworks/weaveDemo
-cd kubernetes/terraform
+git clone https://github.com/microservices-demo/microservices-demo
+cd deploy/kubernetes/terraform
 ```
 
 Add AWS credentials to main.tf file

--- a/install/aws-minimesos/provision.sh
+++ b/install/aws-minimesos/provision.sh
@@ -21,8 +21,8 @@ sudo curl -L git.io/weave -o /usr/local/bin/weave
 sudo chmod +x /usr/local/bin/weave
 
 # Clone repo to get deployment scripts
-git clone https://github.com/weaveworks/weaveDemo.git
-cd weaveDemo
+git clone https://github.com/microservices-demo/microservices-demo.git
+cd microservices-demo
 
 cd deploy/minimesos-marathon
 ./minimesos-marathon.sh start

--- a/sockshop/catalogue/Dockerfile
+++ b/sockshop/catalogue/Dockerfile
@@ -2,12 +2,12 @@ FROM golang:1.6
 
 COPY socks.json /config/socks.json
 RUN mkdir /app
-COPY . /go/src/github.com/weaveworks/weaveDemo/catalogue/
+COPY . /go/src/github.com/microservices-demo/microservices-demo/catalogue/
 COPY images/ /app/images/
 
 RUN go get github.com/gorilla/mux github.com/go-kit/kit/log github.com/go-kit/kit/endpoint github.com/go-kit/kit/transport/http
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/weaveworks/weaveDemo/catalogue/cmd/cataloguesvc
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/microservices-demo/microservices-demo/catalogue/cmd/cataloguesvc
 
 CMD ["/app/main", "-port=80"]
 

--- a/sockshop/catalogue/cmd/cataloguesvc/main.go
+++ b/sockshop/catalogue/cmd/cataloguesvc/main.go
@@ -14,7 +14,7 @@ import (
 
 	"sort"
 
-	"github.com/weaveworks/weaveDemo/catalogue"
+	"github.com/microservices-demo/microservices-demo/sockshop/catalogue"
 	"golang.org/x/net/context"
 	"path/filepath"
 )

--- a/sockshop/login/Dockerfile
+++ b/sockshop/login/Dockerfile
@@ -2,11 +2,11 @@ FROM golang:1.6
 
 COPY users.json /config/users.json
 RUN mkdir /app
-COPY . /go/src/github.com/weaveworks/weaveDemo/login/
+COPY . /go/src/github.com/microservices-demo/microservices-demo/login/
 
 RUN go get github.com/gorilla/mux github.com/go-kit/kit/log github.com/go-kit/kit/endpoint github.com/go-kit/kit/transport/http
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/weaveworks/weaveDemo/login/cmd/loginsvc
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/microservices-demo/microservices-demo/login/cmd/loginsvc
 
 CMD ["/app/main", "-port=80"]
 

--- a/sockshop/login/cmd/loginsvc/main.go
+++ b/sockshop/login/cmd/loginsvc/main.go
@@ -12,7 +12,7 @@ import (
 
 	"net/http"
 
-	"github.com/weaveworks/weaveDemo/login"
+	"github.com/microservices-demo/microservices-demo/sockshop/login"
 	"golang.org/x/net/context"
 )
 

--- a/sockshop/openapi/generate-server.sh
+++ b/sockshop/openapi/generate-server.sh
@@ -16,7 +16,7 @@ if [[ "$module" == "" ]] || [[ "$output" == "" ]] ; then
     exit 1
 fi
 
-fileUrl=https://raw.githubusercontent.com/weaveworks/microservices-demo/"$(git rev-parse HEAD)"/sockshop/openapi/"$module"
+fileUrl=https://raw.githubusercontent.com/microservices-demo/microservices-demo/"$(git rev-parse HEAD)"/sockshop/openapi/"$module"
 
 if ! out=$(curl -sf $fileUrl); then
     echo "Couldn't get the file at $fileUrl"

--- a/sockshop/payment/Dockerfile
+++ b/sockshop/payment/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.6
 
 RUN mkdir /app
-COPY . /go/src/github.com/weaveworks/microservices-demo/sockshop/payment/
+COPY . /go/src/github.com/microservices-demo/microservices-demo/sockshop/payment/
 
 RUN go get -v github.com/gorilla/mux github.com/go-kit/kit/log github.com/go-kit/kit/endpoint github.com/go-kit/kit/transport/http
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/weaveworks/microservices-demo/sockshop/payment/cmd/paymentsvc
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/microservices-demo/microservices-demo/sockshop/payment/cmd/paymentsvc
 
 CMD ["/app/main", "-port=80"]
 

--- a/sockshop/payment/cmd/paymentsvc/main.go
+++ b/sockshop/payment/cmd/paymentsvc/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/weaveworks/microservices-demo/sockshop/payment"
+	"github.com/microservices-demo/microservices-demo/sockshop/payment"
 	"golang.org/x/net/context"
 	"net/http"
 	"os"

--- a/testing/util/Golang.py
+++ b/testing/util/Golang.py
@@ -15,4 +15,4 @@ class Golang():
         docker = Docker()
         docker.execute(['docker', 'build', '-t', test_container_name, code_dir])
         docker.execute(['docker', 'run', '--rm', test_container_name, 'go', 'test',
-                        'github.com/weaveworks/weaveDemo/' + self.container_dir])
+                        'github.com/microservices-demo/microservices-demo/' + self.container_dir])


### PR DESCRIPTION
This repository has been moved to:
https://github.com/microservices-demo/microservices-demo

This includes changes in the documentation, scripts, go includes.

---

/cc @krnowak @alepuccetti
