### PR TITLE
k8s definitions: do not use hostPort

### DIFF
--- a/deploy/kubernetes/definitions/accounts.yaml
+++ b/deploy/kubernetes/definitions/accounts.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: accounts
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -52,7 +50,6 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
-          hostPort: 27017
 ---
 apiVersion: v1
 kind: Service
@@ -61,8 +58,6 @@ metadata:
   labels:
     name: accounts-db
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 27017

--- a/deploy/kubernetes/definitions/cart.yaml
+++ b/deploy/kubernetes/definitions/cart.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: cart
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -52,7 +50,6 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
-          hostPort: 27017
 ---
 apiVersion: v1
 kind: Service
@@ -61,8 +58,6 @@ metadata:
   labels:
     name: cart-db
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 27017

--- a/deploy/kubernetes/definitions/catalogue.yaml
+++ b/deploy/kubernetes/definitions/catalogue.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: catalogue
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80

--- a/deploy/kubernetes/definitions/login.yaml
+++ b/deploy/kubernetes/definitions/login.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: login
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80

--- a/deploy/kubernetes/definitions/orders.yaml
+++ b/deploy/kubernetes/definitions/orders.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: orders
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -52,7 +50,6 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
-          hostPort: 27017
 ---
 apiVersion: v1
 kind: Service
@@ -61,8 +58,6 @@ metadata:
   labels:
     name: orders-db
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 27017

--- a/deploy/kubernetes/definitions/payment.yaml
+++ b/deploy/kubernetes/definitions/payment.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: payment
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80

--- a/deploy/kubernetes/definitions/queue-master.yaml
+++ b/deploy/kubernetes/definitions/queue-master.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: queue-master
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80

--- a/deploy/kubernetes/definitions/rabbitmq.yaml
+++ b/deploy/kubernetes/definitions/rabbitmq.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: rabbitmq
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 5672

--- a/deploy/kubernetes/definitions/shipping.yaml
+++ b/deploy/kubernetes/definitions/shipping.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: shipping
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80

--- a/deploy/kubernetes/definitions/wholeWeaveDemo.yaml
+++ b/deploy/kubernetes/definitions/wholeWeaveDemo.yaml
@@ -24,8 +24,6 @@ metadata:
   labels:
     name: accounts
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -52,7 +50,6 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
-          hostPort: 27017
 ---
 apiVersion: v1
 kind: Service
@@ -61,8 +58,6 @@ metadata:
   labels:
     name: accounts-db
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 27017
@@ -96,8 +91,6 @@ metadata:
   labels:
     name: cart
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -124,7 +117,6 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
-          hostPort: 27017
 ---
 apiVersion: v1
 kind: Service
@@ -133,8 +125,6 @@ metadata:
   labels:
     name: cart-db
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 27017
@@ -168,8 +158,6 @@ metadata:
   labels:
     name: catalogue
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -238,8 +226,6 @@ metadata:
   labels:
     name: login
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -273,8 +259,6 @@ metadata:
   labels:
     name: orders
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -301,7 +285,6 @@ spec:
         ports:
         - name: mongo
           containerPort: 27017
-          hostPort: 27017
 ---
 apiVersion: v1
 kind: Service
@@ -310,8 +293,6 @@ metadata:
   labels:
     name: orders-db
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 27017
@@ -345,8 +326,6 @@ metadata:
   labels:
     name: payment
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -380,8 +359,6 @@ metadata:
   labels:
     name: queue-master
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80
@@ -415,8 +392,6 @@ metadata:
   labels:
     name: rabbitmq
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 5672
@@ -450,8 +425,6 @@ metadata:
   labels:
     name: shipping
 spec:
-  # if your cluster supports it, uncomment the following to automatically create
-  # an external load-balanced IP for the frontend service.
   ports:
     # the port that this service should serve on
   - port: 80


### PR DESCRIPTION
There was three "mongo" deployments listening on the same
containerPort=27017. Binding the same port on the host is not necessary
because we use Kubernetes services to proxy the connections. It prevents
the pods to be scheduled on the same host.

Also, remove some obsolete comments referring to type=LoadBalancer that
has been removed a while ago.

---

/cc @krnowak @alepuccetti
