### PR TITLE
Change all deploys to use accounts-db-test

### DIFF
--- a/deploy/aws-ecs/task-definitions/accounts-db.json
+++ b/deploy/aws-ecs/task-definitions/accounts-db.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "essential": true,
-            "image": "mongo",
+            "image": "weaveworksdemos/accounts-db-test",
             "memory": 256,
             "name": "accounts-db"
         }

--- a/deploy/docker-only/docker-compose.yml
+++ b/deploy/docker-only/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       - reschedule:on-node-failure
   accounts-db:
-    image: mongo
+    image: weaveworksdemos/accounts-db-test
     hostname: accounts-db
     restart: always
     environment:

--- a/deploy/docker-single/docker-compose.yml
+++ b/deploy/docker-single/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     networks:
       - secure
   accounts-db:
-    image: mongo
+    image: weaveworksdemos/accounts-db-test
     hostname: accounts-db
     dns: 172.17.0.1
     dns_search: weave.local

--- a/deploy/docker-swarm/docker-compose.yml
+++ b/deploy/docker-swarm/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     networks:
       - secure
   accounts-db:
-    image: mongo
+    image: weaveworksdemos/accounts-db-test
     hostname: accounts-db
     domainname: weave.local
     restart: always

--- a/deploy/kubernetes/definitions/accounts.yaml
+++ b/deploy/kubernetes/definitions/accounts.yaml
@@ -48,7 +48,8 @@ spec:
     spec:
       containers:
       - name: accounts-db
-        image: mongo
+        image: weaveworksdemos/accounts-db-test
+
         ports:
         - name: mongo
           containerPort: 27017

--- a/deploy/mesos-cni/mesos-cni.sh
+++ b/deploy/mesos-cni/mesos-cni.sh
@@ -421,7 +421,7 @@ do_start() {
 
     wait_task_running "edge-router"
 
-    launch_service accounts-db  "echo ok"                                       mongo                               --no-shell
+    launch_service accounts-db  "echo ok"                                       weaveworksdemos/accounts-db-test:$tag   --no-shell
     launch_service cart-db      "echo ok"                                       mongo                               --no-shell
     launch_service orders-db    "echo ok"                                       mongo                               --no-shell
 

--- a/deploy/mesos-marathon/marathon.json
+++ b/deploy/mesos-marathon/marathon.json
@@ -11,7 +11,7 @@
           "container": {
             "type": "DOCKER",
             "docker": {
-              "image": "mongo",
+              "image": "weaveworksdemos/accounts-db-test",
               "network": "BRIDGE",
               "parameters": [
                 {

--- a/deploy/nomad/jobs/weavedemo.nomad
+++ b/deploy/nomad/jobs/weavedemo.nomad
@@ -128,7 +128,7 @@ job "weavedemo" {
       driver = "docker"
 
       config {
-        image = "mongo"
+        image = "weaveworksdemos/accounts-db-test"
         hostname = "accounts-db.weave.local"
         network_mode = "secure"
       }

--- a/deploy/swarmkit/start-swarmkit-services.sh
+++ b/deploy/swarmkit/start-swarmkit-services.sh
@@ -73,7 +73,7 @@ echo "Creating accounts-db service"
 docker service create \
        --name accounts-db \
        --network ingress \
-       --env "reschedule=on-node-failure" mongo
+       --env "reschedule=on-node-failure" weaveworksdemos/accounts-db-test:latest
 exit_on_failure
 
 


### PR DESCRIPTION
All deploys should now use the custom db `weaveworksdemos/accounts-db-test`. This is a mongo image packaged with the dummy data, ready to go.

Do not merge until accounts is released.
