### PR TITLE
Add mysql env variables to service

### DIFF
--- a/deploy/swarmkit/start-swarmkit-services.sh
+++ b/deploy/swarmkit/start-swarmkit-services.sh
@@ -66,7 +66,10 @@ echo "Creating catalogue-db service"
 docker service create \
        --name catalogue-db \
        --network ingress \
-       --env "reschedule=on-node-failure" mysql
+        --env "reschedule=on-node-failure" \
+        --env "MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}" \
+        --env "MYSQL_DATABASE=socksdb" \
+       mysql
 exit_on_failure
 
 echo "Creating accounts service"


### PR DESCRIPTION
The catalogue-db swarm mode service fails because the env variables for MySQL are undefined, this PR adds them. 
