### PR TITLE
Fix openapi Dockerfile

### DIFF
--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -1,12 +1,17 @@
 FROM mhart/alpine-node:6.3
 
+ENV NODE_ENV "production"
+ENV NODE_PATH "/usr/src/app/node_modules"
+
+# Install base dependencies
+RUN apk update
+RUN apk add git python
+
 # Prepare app directory
 WORKDIR /usr/src/app
 COPY . /usr/src/app
-RUN npm install 
+RUN npm install
 VOLUME /tmp/specs
 
-ENV NODE_ENV "production"
-ENV NODE_PATH "/usr/src/app/node_modules"
 # Start the app
-ENTRYPOINT [ "/usr/src/app/node_modules/dredd/bin/dredd" ]
+ENTRYPOINT ["/usr/src/app/node_modules/dredd/bin/dredd"]


### PR DESCRIPTION
Some NodeJS dependencies were failing to be installed because missing
libraries (git & python) were missing.

This commit installs those dependencies and now everything is back to
normal.
