### PR TITLE
Add Kubernetes network policies

### DIFF
--- a/deploy/kubernetes/manifests/network-policies.yaml
+++ b/deploy/kubernetes/manifests/network-policies.yaml
@@ -1,0 +1,232 @@
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: user-db-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: user-db
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: user
+      ports:
+        - protocol: TCP
+          port: 27017
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: catalogue-db-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: catalogue-db
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: catalogue
+      ports:
+        - protocol: TCP
+          port: 3306
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: cart-db-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: cart-db
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: cart
+      ports:
+        - protocol: TCP
+          port: 27017
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: orders-db-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: orders-db
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: orders
+      ports:
+        - protocol: TCP
+          port: 27017
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: user-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: user
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: front-end
+        - podSelector:
+            matchLabels:
+              name: orders
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: catalogue-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: catalogue
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: front-end
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: cart-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: cart
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: front-end
+        - podSelector:
+            matchLabels:
+              name: orders
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: orders-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: orders
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: front-end
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: shipping-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: shipping
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: orders
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: payment-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: payment
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: orders
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: rabbitmq-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: rabbitmq
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: shipping
+        - podSelector:
+            matchLabels:
+              name: queue-master
+      ports:
+        - protocol: TCP
+          port: 5672
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: front-end-access
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: front-end
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8079
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: default
+  annotations:
+    net.beta.kubernetes.io/network-policy: |
+      {
+        "ingress": {
+          "isolation": "DefaultDeny"
+        }
+      }


### PR DESCRIPTION
Set the `default` namespace's ingress isolation policy to `DefaultDeny`, and add policies to allow sanctioned communications between services.
