### PR TITLE
Change Kubernetes manifests from 'default' namespace to 'sock-shop'

### DIFF
--- a/deploy/kubernetes/manifests/cart-db-dep.yaml
+++ b/deploy/kubernetes/manifests/cart-db-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cart-db
   labels:
     name: cart-db
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/cart-db-svc.yaml
+++ b/deploy/kubernetes/manifests/cart-db-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cart-db
   labels:
     name: cart-db
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/cart-dep.yaml
+++ b/deploy/kubernetes/manifests/cart-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cart
   labels:
     name: cart
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/cart-svc.yaml
+++ b/deploy/kubernetes/manifests/cart-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cart
   labels:
     name: cart
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-db-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: catalogue-db
   labels:
     name: catalogue-db
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/catalogue-db-svc.yaml
+++ b/deploy/kubernetes/manifests/catalogue-db-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: catalogue-db
   labels:
     name: catalogue-db
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: catalogue
   labels:
     name: catalogue
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/catalogue-svc.yaml
+++ b/deploy/kubernetes/manifests/catalogue-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: catalogue
   labels:
     name: catalogue
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/front-end-dep.yaml
+++ b/deploy/kubernetes/manifests/front-end-dep.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: front-end
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/front-end-svc.yaml
+++ b/deploy/kubernetes/manifests/front-end-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: front-end
   labels:
     name: front-end
+  namespace: sock-shop
 spec:
   type: NodePort
   ports:

--- a/deploy/kubernetes/manifests/netpol-cart-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-cart-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: cart-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-cart-db-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-cart-db-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: cart-db-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-catalogue-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-catalogue-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: catalogue-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-catalogue-db-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-catalogue-db-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: catalogue-db-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-default-deny.yaml
+++ b/deploy/kubernetes/manifests/netpol-default-deny.yaml
@@ -2,7 +2,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: default
+  name: sock-shop
   annotations:
     net.beta.kubernetes.io/network-policy: |
       {

--- a/deploy/kubernetes/manifests/netpol-frontend-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-frontend-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: front-end-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-orders-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-orders-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: orders-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-orders-db-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-orders-db-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: orders-db-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-payment-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-payment-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: payment-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-prism-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-prism-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: prism-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-rabbitmq-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-rabbitmq-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: rabbitmq-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-shipping-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-shipping-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: shipping-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-user-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-user-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: user-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/netpol-user-db-access.yaml
+++ b/deploy/kubernetes/manifests/netpol-user-db-access.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: user-db-access
-  namespace: default
+  namespace: sock-shop
 spec:
   podSelector:
     matchLabels:

--- a/deploy/kubernetes/manifests/orders-db-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-db-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: orders-db
   labels:
     name: orders-db
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/orders-db-svc.yaml
+++ b/deploy/kubernetes/manifests/orders-db-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: orders-db
   labels:
     name: orders-db
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/orders-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: orders
   labels:
     name: orders
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/orders-svc.yaml
+++ b/deploy/kubernetes/manifests/orders-svc.yaml
@@ -7,6 +7,7 @@ metadata:
     name: orders
   annotations:
     prometheus.io.path: "/prometheus"
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/payment-dep.yaml
+++ b/deploy/kubernetes/manifests/payment-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: payment
   labels:
     name: payment
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/payment-svc.yaml
+++ b/deploy/kubernetes/manifests/payment-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: payment
   labels:
     name: payment
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/queue-master-dep.yaml
+++ b/deploy/kubernetes/manifests/queue-master-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: queue-master
   labels:
     name: queue-master
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/queue-master-svc.yaml
+++ b/deploy/kubernetes/manifests/queue-master-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: queue-master
   labels:
     name: queue-master
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/manifests/rabbitmq-dep.yaml
@@ -5,6 +5,7 @@ metadata:
   name: rabbitmq
   labels:
     name: rabbitmq
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/rabbitmq-svc.yaml
+++ b/deploy/kubernetes/manifests/rabbitmq-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: rabbitmq
   labels:
     name: rabbitmq
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/shipping-dep.yml
+++ b/deploy/kubernetes/manifests/shipping-dep.yml
@@ -5,6 +5,7 @@ metadata:
   name: shipping
   labels:
     name: shipping
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/shipping-svc.yml
+++ b/deploy/kubernetes/manifests/shipping-svc.yml
@@ -5,6 +5,7 @@ metadata:
   name: shipping
   labels:
     name: shipping
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/user-db-dep.yml
+++ b/deploy/kubernetes/manifests/user-db-dep.yml
@@ -5,6 +5,7 @@ metadata:
   name: user-db
   labels:
     name: user-db
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/user-db-svc.yml
+++ b/deploy/kubernetes/manifests/user-db-svc.yml
@@ -5,6 +5,7 @@ metadata:
   name: user-db
   labels:
     name: user-db
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on

--- a/deploy/kubernetes/manifests/user-dep.yml
+++ b/deploy/kubernetes/manifests/user-dep.yml
@@ -5,6 +5,7 @@ metadata:
   name: user
   labels:
     name: user
+  namespace: sock-shop
 spec:
   replicas: 1
   template:

--- a/deploy/kubernetes/manifests/user-svc.yml
+++ b/deploy/kubernetes/manifests/user-svc.yml
@@ -5,6 +5,7 @@ metadata:
   name: user
   labels:
     name: user
+  namespace: sock-shop
 spec:
   ports:
     # the port that this service should serve on


### PR DESCRIPTION
So that we can install our network policies just in the sock-shop namespace, and avoid breaking anything else the user is running in 'default'

Note that `deploy/kubernetes/README.md` references `deploy/kubernetes/definitions/wholeWeaveDemo.yaml` which does not have any network policies, so I have not changed either.
