### PR TITLE
Add Kubernetes sock-shop namespace manifest file

### DIFF
--- a/deploy/kubernetes/manifests/sock-shop-ns.yml
+++ b/deploy/kubernetes/manifests/sock-shop-ns.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sock-shop


### PR DESCRIPTION
#339 broke installing the demo in Kubernetes with a simple

```
# kubectl apply -f microservices-demo/deploy/kubernetes/manifests
```

as documented in the [official Kubernetes docs](http://kubernetes.io/docs/getting-started-guides/kubeadm/) for `kubeadm` due to the introduction of a new namespace `sock-shop` which isn't likely to exist beforehand. Therefore, users going through the documentation will receive an unexpected error when running the command.

Adding a manifest file to create the namespace fixes this. I've tested the workflow with:

```
# git clone https://github.com/axsuul/microservices-demo
# kubectl apply -f microservices-demo/deploy/kubernetes/manifests
```
