### PR TITLE
Testable deployment documentation

### DIFF
--- a/deploy/aws-ecs/README.md
+++ b/deploy/aws-ecs/README.md
@@ -1,3 +1,5 @@
+<!-- deploy-test require-env AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION -->
+
 # Setup and Installation on AWS ECS
 
 ## Goal
@@ -20,20 +22,34 @@ As this app is fairly large, you should set ***`Scale`*** to 4 and select `m3.xl
 
 To use CLI, you also need to have the [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html) set up and configured.
 
-#### Setup
+Install it on ubuntu with the following steps:
+<!-- deploy-test-start pre-install -->
+apt-get -yq update
+apt-get -yq install curl coreutils python python-pip jq
+pip install awscli
+<!-- deploy-test-end -->
 
 To deploy and start the demo, run the setup script to deploy to ECS:
 
-    ./setup.sh
+<!-- deploy-test-start create-infrastructure -->
+    STORE_DNS_NAME_HERE=ecs-endpoint ./setup.sh
+<!-- deploy-test-end -->
 
 This may take a few minutes to complete. Once it's done, it will print the URL for the demo frontend, as well as the URL for the Weave Scope instance that can be used to visualize the containers and their connections.
+
+To ensure that the application is running properly, you could perform some load testing on it:
+
+<!-- deploy-test-start run-tests -->
+    docker run weaveworksdemos/load-test -h  `cat ecs-endpoint` -c 10 -r 100
+<!-- deploy-test-end -->
 
 #### Cleanup
 
 To tear down the containers and their associated AWS objects, run the cleanup script:
 
+<!-- deploy-test-start destroy-infrastructure -->
     ./cleanup.sh
-
+<!-- deploy-test-end -->
 
 #### Background
 

--- a/deploy/aws-ecs/README.md
+++ b/deploy/aws-ecs/README.md
@@ -24,9 +24,9 @@ To use CLI, you also need to have the [AWS CLI](http://docs.aws.amazon.com/cli/l
 
 Install it on ubuntu with the following steps:
 <!-- deploy-test-start pre-install -->
-apt-get -yq update
-apt-get -yq install curl coreutils python python-pip jq
-pip install awscli
+    apt-get -yq update
+    apt-get -yq install curl coreutils python python-pip jq
+    pip install awscli
 <!-- deploy-test-end -->
 
 To deploy and start the demo, run the setup script to deploy to ECS:

--- a/deploy/aws-ecs/scripts/setup3-showconf.sh
+++ b/deploy/aws-ecs/scripts/setup3-showconf.sh
@@ -17,3 +17,8 @@ echo "  http://$dns_name/"
 echo
 echo "To view the Weave Scope for the demo, go to this URL:"
 echo "  http://${dns_name}:4040/"
+
+# And store it in a file, if requested.
+if [ "x$STORE_DNS_NAME_HERE" != "x" ]; then
+  echo "$dns_name" > $STORE_DNS_NAME_HERE
+fi

--- a/deploy/docker-only/README.md
+++ b/deploy/docker-only/README.md
@@ -9,10 +9,40 @@ DNS is achieved by using the internal Docker DNS, which reads network alias entr
 - Install Docker
 - Install [Weave Scope](https://www.weave.works/install-weave-scope/)
 
-## Install & run
+<!-- deploy-test-start pre-install -->
+    apt-get install -yq curl
 
-    curl -L https://raw.githubusercontent.com/microservices-demo/microservices-demo/master/deploy/docker-only/docker-compose.yml -o docker-compose.yml
-    docker-compose up -d
+    curl -L https://github.com/docker/compose/releases/download/1.8.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+ 
+<!-- deploy-test-end -->
+
+## Provision infrastructure
+
+<!-- deploy-test-start create-infrastructure -->
+
+    docker-compose up -d user-db user catalogue-db catalogue rabbitmq queue-master cart-db cart orders-db shipping payment orders front-end edge-router
+    
+<!-- deploy-test-end -->
+
+## Run tests
+
+Run the user similator load test. For more information see [Load Test](#loadtest)
+
+<!-- deploy-test-start run-tests -->
+
+    docker run weaveworksdemos/load-test -d 60 -h edge-router -c 3 -r 10
+
+<!-- deploy-test-end -->
+
+## Cleaning up
+
+<!-- deploy-test-start destroy-infrastructure -->
+
+    docker-compose stop
+    docker-compose rm -f
+
+<!-- deploy-test-end -->
 
 ## Launch Weave Scope or Weave Cloud
 

--- a/deploy/example/README.md
+++ b/deploy/example/README.md
@@ -1,0 +1,40 @@
+# Example documentation
+
+Hi, cool docs over here.
+
+
+We need to install some tools before we start:
+<!-- deploy-test pre-install -->
+
+    apt-get install -yq cowsay
+
+<!-- deploy-test-end -->
+
+# Provision infrastucture
+
+We first have to provision some instances.
+
+<!-- deploy-test-start create-infrastructure -->
+
+    gcloud instances create blah
+
+<!-- deploy-test-end -->
+
+Now you can play around with your cluster!
+
+<!-- now we can run the tests, hidden from the end-user -->
+<!-- deploy-test-start run-tests
+
+    cd /path/of/tests;
+    ./run_tests
+-->
+
+# Cleaning up
+If you're done, clean up your cluster with these commands:
+
+<!-- deploy-test-start destroy-infrastructure -->
+
+    gcloud destroy blah
+
+<!-- deploy-test-end -->
+

--- a/deploy/tests/Dockerfile
+++ b/deploy/tests/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:xenial
+VOLUME /to-test
+WORKDIR /to-test
+
+RUN apt-get update && apt-get install -yq ruby
+COPY ./runner/test-documentation /test-documentation
+CMD /test-documentation

--- a/deploy/tests/Dockerfile
+++ b/deploy/tests/Dockerfile
@@ -3,5 +3,9 @@ VOLUME /to-test
 WORKDIR /to-test
 
 RUN apt-get update && apt-get install -yq ruby
+RUN apt-get update && apt-get install -yq apt-transport-https ca-certificates
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+RUN echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" > /etc/apt/sources.list.d/docker.list
+RUN apt-get update && apt-get install -yq docker-engine
 COPY ./runner/test-documentation /test-documentation
 CMD /test-documentation

--- a/deploy/tests/Makefile
+++ b/deploy/tests/Makefile
@@ -1,11 +1,20 @@
 .PHONY: all_tests docker_container check-ecs2-env
-test_all: docker_container test_ecs
+help:
+	cat Makefile
+
+test_all: docker_only test_ecs
 
 docker_container:
 	docker build -t microservice-demo-docdoctor .
 
-test_example:
+test_example: docker_container
 	docker run --rm -ti -v $(shell pwd)/../example:/to-test microservice-demo-docdoctor
+
+test_docker_only: docker_container
+	docker run --rm -ti \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(shell pwd)/../docker-only:/to-test \
+		microservice-demo-docdoctor
 
 test_ecs: check-ec2-env
 	docker run --rm -ti \

--- a/deploy/tests/Makefile
+++ b/deploy/tests/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all_tests docker_container 
+all_tests: docker_container example
+
+docker_container:
+	docker build -t microservice-demo-docdoctor .
+
+example:
+	docker run --rm -ti -v $(shell pwd)/../example:/to-test microservice-demo-docdoctor

--- a/deploy/tests/Makefile
+++ b/deploy/tests/Makefile
@@ -26,6 +26,6 @@ test_ecs: check-ec2-env
 		microservice-demo-docdoctor
 
 check-ec2-env:
-	@if [ "x$$AWS_ACCESS_KEY_ID" == "x" ]; then echo "AWS_ACCESS_KEY_ID not set!"; exit 1; fi
-	@if [ "x$$AWS_SECRET_ACCESS_KEY" == "x" ]; then echo "AWS_SECRET_ACCESS_KEY not set!"; exit 1; fi
-	@if [ "x$$AWS_DEFAULT_REGION" == "x" ]; then echo "AWS_DEFAULT_REGION not set!"; exit 1; fi
+	@if [ "x$$AWS_ACCESS_KEY_ID" = "x" ]; then echo "AWS_ACCESS_KEY_ID not set!"; exit 1; fi
+	@if [ "x$$AWS_SECRET_ACCESS_KEY" = "x" ]; then echo "AWS_SECRET_ACCESS_KEY not set!"; exit 1; fi
+	@if [ "x$$AWS_DEFAULT_REGION" = "x" ]; then echo "AWS_DEFAULT_REGION not set!"; exit 1; fi

--- a/deploy/tests/Makefile
+++ b/deploy/tests/Makefile
@@ -1,8 +1,22 @@
-.PHONY: all_tests docker_container 
-all_tests: docker_container example
+.PHONY: all_tests docker_container check-ecs2-env
+test_all: docker_container test_ecs
 
 docker_container:
 	docker build -t microservice-demo-docdoctor .
 
-example:
+test_example:
 	docker run --rm -ti -v $(shell pwd)/../example:/to-test microservice-demo-docdoctor
+
+test_ecs: check-ec2-env
+	docker run --rm -ti \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(shell pwd)/../aws-ecs:/to-test \
+		-e AWS_ACCESS_KEY_ID="$$AWS_ACCESS_KEY_ID" \
+		-e AWS_SECRET_ACCESS_KEY="$$AWS_SECRET_ACCESS_KEY" \
+		-e AWS_DEFAULT_REGION="$$AWS_DEFAULT_REGION" \
+		microservice-demo-docdoctor
+
+check-ec2-env:
+	@if [ "x$$AWS_ACCESS_KEY_ID" == "x" ]; then echo "AWS_ACCESS_KEY_ID not set!"; exit 1; fi
+	@if [ "x$$AWS_SECRET_ACCESS_KEY" == "x" ]; then echo "AWS_SECRET_ACCESS_KEY not set!"; exit 1; fi
+	@if [ "x$$AWS_DEFAULT_REGION" == "x" ]; then echo "AWS_DEFAULT_REGION not set!"; exit 1; fi

--- a/deploy/tests/runner/test-documentation
+++ b/deploy/tests/runner/test-documentation
@@ -1,0 +1,247 @@
+#!/usr/bin/env ruby
+# Executable documentation
+
+# Valid syntax for deployment test annotations
+# Nesting is not supported.
+# 1. Single line annotation, not visibile in Markdown output
+#  "<!-- deploy-test name [VALUE]* -->"
+# 2. Hidden multiline annotation
+#  "<!-- deploy-test-start name [VALUE]*"
+#  CONTENT
+#  "-->"
+# 3. Visible multiline annotation
+#  "<!-- deploy-test-start name [VALUE]* -->"
+#  CONTENT
+#  "<!-- deploy-test-end -->"
+
+require 'pp'
+
+def main
+  test_plan = DeploymentTestPlan.from_file("README.md")
+  puts test_plan.to_s
+  if test_plan.execute!
+    exit 0
+  else
+    exit 1
+  end
+end
+
+
+class DeploymentTestPlan
+  PHASES = ["pre-install", "create-infrastructure", "run-tests", "destroy-infrastructure"]
+
+  class Step < Struct.new(:source_name, :line_span, :shell)
+    def full_name
+      "#{source_name}:#{line_span.inspect}"
+    end
+  end
+
+  def self.from_file(file)
+    annotations = AnnotationParser.parse_file(file)
+    DeploymentTestPlan.from_annotations(annotations)
+  end
+
+  def self.from_annotations(annotations)
+    required_env_vars = (annotations.select { |a| a.kind == "require-env" }).map { |a| a.params }.flatten
+    phases = {}
+
+    PHASES.each do |phase|
+      phases[phase] = (annotations.select { |a| a.kind == phase }).map { |a| Step.new(a.source_name, a.line_span, a.content) }
+    end
+
+    DeploymentTestPlan.new(required_env_vars, phases)
+  end
+
+
+  def initialize(required_env_vars, steps_in_phases)
+    @required_env_vars = required_env_vars
+    @steps_in_phases = steps_in_phases
+  end
+
+  def to_s
+   parts = []
+   parts << "Deployment test plan:"
+   parts << ""
+   parts << "Required environment parameters"
+
+   @required_env_vars.each do |e|
+     parts << "  - #{e}"
+   end
+
+   PHASES.each do |phase|
+     parts << "Steps in phase #{phase}:"
+     @steps_in_phases[phase].each do |step|
+       parts << "- #{step.source_name}:#{step.line_span.inspect}"
+       parts << step.shell
+     end
+   end
+
+   parts.join("\n")
+  end
+
+  def execute!
+    missing_envs = @required_env_vars.select { |e| ENV[e].nil? }
+    if missing_envs.any?
+      $stderr.puts "Missing the following required environment variables:"
+      $stderr.puts missing_envs.inspect
+      exit 1
+    end
+
+    execute_phase("pre-install")
+    begin
+      execute_phase("create-infrastructure")
+      execute_phase("run-tests")
+      return true
+    rescue Exception => e
+      p e
+      return false
+    ensure # Clean up the infrastructure
+      begin
+        execute_phase("destroy-infrastructure")
+        rescue Exception  => e
+        $stderr.puts "Failed to clean up  the infrastructure!"
+        exit 2
+      end
+    end
+  end
+
+  def execute_phase(phase_name)
+    puts "Executing phase #{phase_name}"
+    steps = @steps_in_phases[phase_name]
+
+    steps.each do |step|
+      puts "Running step #{step.full_name}"
+      system(step.shell)
+      if $?.exitstatus != 0
+        raise("Could not finish step #{step.full_name} in phase #{phase_name}")
+      end
+    end
+  end
+end
+
+class AnnotationParser
+  Annotation = Struct.new(:source_name, :line_span, :kind, :params, :content)
+
+  def self.parse_file(file)
+    AnnotationParser.new(File.read(file), file).parse!
+  end
+
+  def initialize(markdown, source_name="<unknown>")
+    @source_name = source_name
+    @markdown_lines = markdown.split("\n")
+  end
+
+  def parse!
+    @annotations = []
+    @parse_idx = 0
+
+
+    while !eof_reached?
+      parse_block || parse_inline || parse_single_line || parse_text
+    end
+
+    @annotations
+  end
+
+  private
+
+  def parse_text
+    # ignore text
+    inc_line
+  end
+
+  BLOCK_START  = /^<!-- deploy-test-start (?<kind>[-\w]+)( )?(?<params>.*) -->/
+  BLOCK_END    = /^<!-- deploy-test-end -->/
+
+  INLINE_START = /^<!-- deploy-test-hidden (?<kind>[-\w]+)( )?(?<params>.*)/
+  INLINE_END   = /^-->/
+
+  SINGLE_LINE  = /^<!-- deploy-test (?<kind>[-\w]+)( )?(?<params>.*) -->/
+
+
+  PARSE_METHOD_PREFIX = "parse_pragma_"
+
+  def parse_block
+    if (match = BLOCK_START.match(current_line)).nil?
+      false
+    else
+      inc_line
+      start_line = current_line_nr
+      kind = match["kind"]
+      params = match["params"].split(/\s+/)
+      content = ""
+      loop do
+        if eof_reached?
+          raise("Unexpected end of file; --> not closed? started on #{@source_name}:#{start_line}")
+        elsif !(BLOCK_END.match(current_line).nil?)
+          end_line = current_line_nr() -1
+          @annotations << Annotation.new(@source_name, [start_line, end_line], kind, params, content)
+          return true
+        else
+          content += current_line + "\n"
+        end
+        inc_line
+      end
+      true
+    end
+  end
+
+  def parse_inline
+    if (match = INLINE_START.match(current_line)).nil?
+      false
+    else
+      inc_line
+      start_line = current_line_nr
+      kind = match["kind"]
+      params = match["params"].split(/\s+/)
+      content = ""
+      loop do
+        if eof_reached?
+          raise("Unexpected end of file; --> not closed? started on #{@source_name}:#{start_line}")
+        elsif !(INLINE_END.match(current_line).nil?)
+          end_line = current_line_nr() -1
+          @annotations << Annotation.new(@source_name, [start_line, end_line], kind, params, content)
+          return true
+        else
+          content += current_line + "\n"
+        end
+        inc_line
+      end
+      true
+    end
+  end
+
+  def parse_single_line
+    if (match = SINGLE_LINE.match(current_line)).nil?
+      false
+    else
+      kind = match["kind"]
+      params = match["params"].split(/\s+/)
+      @annotations << Annotation.new(@source_name, [current_line_nr, current_line_nr], kind, params, nil)
+      inc_line
+    end
+  end
+
+  ##### Helper functions ####
+
+  def eof_reached?
+    @parse_idx >= @markdown_lines.length
+  end
+
+  def current_line
+    @markdown_lines[@parse_idx]
+  end
+
+  def current_line_nr
+    @parse_idx + 1
+  end
+
+  def inc_line
+    @parse_idx+=1
+  end
+end
+
+
+if $0 == __FILE__
+  main
+end


### PR DESCRIPTION
In order to test the deployments, we need to invoke a set of steps to run different other programs, such as calls to Terraform, or lower lever utils like gcloud.

These steps could easily get out of sync to the user facing documentation. Therefore, we propose to make the user facing documentation leading. 

This PR will introduce a test Docker container that will parse the `README.md` file in each deployment directory, and extract annotations on which user facing commands should be run.
These steps will then be run by the container, to verify that the deployment of the target platform is successful.

The rationale for using Docker, is that it would provide a reproducible environment for both on our local development machines, and in a CI environment.

I've included a simple [(non-functional) example](https://github.com/microservices-demo/microservices-demo/edit/testable_deployment_documentation/deploy/example/README.md) of how these annotations will look like.

How to run the example:
1. checkout
2. `cd deploy/tests`
3. `make`
    This will only 'test' the example for now.
