### PR TITLE
Add task definition for catalogue-db on aws-ecs

### DIFF
--- a/deploy/aws-ecs/task-definitions/catalogue-db.json
+++ b/deploy/aws-ecs/task-definitions/catalogue-db.json
@@ -1,0 +1,28 @@
+{
+    "family": "weavedemo-catalogue-db",
+    "containerDefinitions": [
+        {
+            "essential": true,
+            "image": "weaveworksdemos/catalogue-db",
+            "memory": 256,
+            "name": "catalogue-db",
+            "environment": [
+              {
+                "name": "MYSQL_ROOT_PASSWORD",
+                "value": "fake_password"
+              },
+              {
+                "name": "MYSQL_DATABASE",
+                "value": "socksdb"
+              }
+            ],
+            "portMappings": [
+              {
+                "containerPort": 3306,
+                "hostPort": 0,
+                "protocol": ""
+              }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add the missing catalogue-db task definition on aws ecs. This causes the catalog to show no socks!
