### PR TITLE
Add `cfn-signal` based on evidence from docs [1, 2] and Github [3]

### DIFF
--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -976,6 +976,25 @@
                       "EcsInstanceLc"
                     ]
                   ]
+                },
+                {
+                  "Fn::Join": [
+                    " ",
+                    [
+                      "/opt/aws/bin/cfn-signal",
+                      "--verbose",
+                      "--stack",
+                      {
+                        "Ref": "AWS::StackName"
+                      },
+                      "--region",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      "--resource",
+                      "EcsInstanceAsg"
+                    ]
+                  ]
                 }
               ]
             ]


### PR DESCRIPTION
It's been said that this should mitigate some of the flakes we have seen with
`Service arn:aws:ecs:... did not stabilize` errors.

It is cleare that `--resource` should refer to the ASG, but it's still
not clear why the docs suggest using `#!/bin/bash -xe` with `cfn-signal -e $? ...`,
as `$?` will always be zere due to `-e`.

It's also not clear whether we really need `/etc/cfn/{cfn-hup,hooks.d/cfn-auto-reloader}.conf`.

[1]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-signal.html
[2]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ecs.html
[3]: https://github.com/convox/rack/blob/46de9944e7e0078f50f282ac5bdcdc89ceed9b8d/provider/aws/dist/rack.json#L1034