### PR TITLE
Review memory limits and default instances, bump AMIs

### DIFF
--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -87,7 +87,7 @@
     "EcsInstanceType": {
       "Type": "String",
       "Description": "Type of the EC2 instance(s) to deploy",
-      "Default": "t2.micro",
+      "Default": "t2.medium",
       "AllowedValues": [
         "t2.micro",
         "t2.small",
@@ -127,7 +127,7 @@
     "Scale": {
       "Type": "Number",
       "Description": "Size of ECS cluster",
-      "Default": "3"
+      "Default": "2"
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName",

--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -182,7 +182,7 @@
             "Essential": true,
             "Image": "mongo",
             "Name": "cart-db",
-            "Memory": 512
+            "Memory": 64
           }
         ],
         "Volumes": []
@@ -210,7 +210,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/cart",
             "Name": "cart",
-            "Memory": 1024
+            "Memory": 512
           }
         ],
         "Volumes": []
@@ -238,7 +238,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/catalogue",
             "Name": "catalogue",
-            "Memory": 1024
+            "Memory": 16
           }
         ],
         "Volumes": []
@@ -266,7 +266,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/catalogue-db",
             "Name": "catalogue-db",
-            "Memory": 512,
+            "Memory": 128,
             "Environment": [
               {
                 "Name": "MYSQL_ROOT_PASSWORD",
@@ -304,7 +304,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/front-end",
             "Name": "front-end",
-            "Memory": 1024,
+            "Memory": 64,
             "PortMappings": [
               {
                 "HostPort": 80,
@@ -340,7 +340,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/user",
             "Name": "user",
-            "Memory": 1024
+            "Memory": 16
           }
         ],
         "Volumes": []
@@ -368,7 +368,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/user-db",
             "Name": "user-db",
-            "Memory": 512
+            "Memory": 64
           }
         ],
         "Volumes": []
@@ -396,7 +396,7 @@
             "Essential": true,
             "Image": "mongo",
             "Name": "orders-db",
-            "Memory": 512
+            "Memory": 64
           }
         ],
         "Volumes": []
@@ -424,7 +424,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/orders",
             "Name": "orders",
-            "Memory": 1024
+            "Memory": 16
           }
         ],
         "Volumes": []
@@ -452,7 +452,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/payment",
             "Name": "payment",
-            "Memory": 1024
+            "Memory": 16
           }
         ],
         "Volumes": []
@@ -521,7 +521,7 @@
             "Essential": true,
             "Image": "rabbitmq:3",
             "Name": "rabbitmq",
-            "Memory": 512
+            "Memory": 64
           }
         ],
         "Volumes": []
@@ -549,7 +549,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/shipping",
             "Name": "shipping",
-            "Memory": 1024
+            "Memory": 512
           }
         ],
         "Volumes": []

--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -55,31 +55,31 @@
     },
     "WeaveworksEcsAmiIds": {
       "us-east-1": {
-        "ImageId": "ami-1924770e"
+        "ImageId": "ami-eca289fb"
       },
       "us-east-2": {
-        "ImageId": "ami-bd3e64d8"
+        "ImageId": "ami-446f3521"
       },
       "us-west-1": {
-        "ImageId": "ami-7f004b1f"
+        "ImageId": "ami-9fadf8ff"
       },
       "us-west-2": {
-        "ImageId": "ami-56ed4936"
+        "ImageId": "ami-7abc111a"
       },
       "eu-west-1": {
-        "ImageId": "ami-c8337dbb"
+        "ImageId": "ami-a1491ad2"
       },
       "eu-central-1": {
-        "ImageId": "ami-dd12ebb2"
+        "ImageId": "ami-54f5303b"
       },
       "ap-northeast-1": {
-        "ImageId": "ami-c8b016a9"
+        "ImageId": "ami-9cd57ffd"
       },
       "ap-southeast-1": {
-        "ImageId": "ami-6d22840e"
+        "ImageId": "ami-a900a3ca"
       },
       "ap-southeast-2": {
-        "ImageId": "ami-73407d10"
+        "ImageId": "ami-5781be34"
       }
     }
   },

--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -182,7 +182,7 @@
             "Essential": true,
             "Image": "mongo",
             "Name": "cart-db",
-            "Memory": 64
+            "Memory": 128
           }
         ],
         "Volumes": []
@@ -238,7 +238,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/catalogue",
             "Name": "catalogue",
-            "Memory": 16
+            "Memory": 32
           }
         ],
         "Volumes": []
@@ -266,7 +266,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/catalogue-db",
             "Name": "catalogue-db",
-            "Memory": 128,
+            "Memory": 512,
             "Environment": [
               {
                 "Name": "MYSQL_ROOT_PASSWORD",
@@ -304,7 +304,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/front-end",
             "Name": "front-end",
-            "Memory": 64,
+            "Memory": 256,
             "PortMappings": [
               {
                 "HostPort": 80,
@@ -340,7 +340,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/user",
             "Name": "user",
-            "Memory": 16
+            "Memory": 32
           }
         ],
         "Volumes": []
@@ -368,7 +368,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/user-db",
             "Name": "user-db",
-            "Memory": 64
+            "Memory": 128
           }
         ],
         "Volumes": []
@@ -396,7 +396,7 @@
             "Essential": true,
             "Image": "mongo",
             "Name": "orders-db",
-            "Memory": 64
+            "Memory": 128
           }
         ],
         "Volumes": []
@@ -424,7 +424,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/orders",
             "Name": "orders",
-            "Memory": 16
+            "Memory": 512
           }
         ],
         "Volumes": []
@@ -452,7 +452,7 @@
             "Essential": true,
             "Image": "weaveworksdemos/payment",
             "Name": "payment",
-            "Memory": 16
+            "Memory": 32
           }
         ],
         "Volumes": []
@@ -521,7 +521,7 @@
             "Essential": true,
             "Image": "rabbitmq:3",
             "Name": "rabbitmq",
-            "Memory": 64
+            "Memory": 128
           }
         ],
         "Volumes": []

--- a/docs/deployment/ecs.md
+++ b/docs/deployment/ecs.md
@@ -22,8 +22,6 @@ To deploy, you will need an [Amazon Web Services (AWS)](http://aws.amazon.com) a
 
 By clicking "Launch Stack" button above, you will get redirected to AWS CloudFormation console. You will be asked to set cluster size (***`Scale`***) and instance type (***`EcsInstanceType`***).
 
-As this app is fairly large, you should set ***`Scale`*** to 4 and select `m3.xlarge` for ***`EcsInstanceType`***.
-
 ### Using CLI
 
 To use CLI, you also need to have the [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html) set up and configured.


### PR DESCRIPTION
This change is aimed to fix #413. I still need to test it under load few times and adjust default instance type, but it looks like we can do away with 3 of `t2.medium` or `t2.large`.

@2opremio PTAL