### PR TITLE
Fix cfn-signal flags

### DIFF
--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -898,7 +898,6 @@
                     " ",
                     [
                       "/opt/aws/bin/cfn-signal",
-                      "--verbose",
                       "--stack",
                       {
                         "Ref": "AWS::StackName"


### PR DESCRIPTION
This flag was missing and it was failing somewhat silently with zero effect (and I doubt overall need for having `cfn-signal`), but let's fix it anyway.