### PR TITLE
Resolve kramdown version issues

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 ruby RUBY_VERSION
 gem "jekyll", "3.3.0"
+# gem 'github-pages', '104', group: :jekyll_plugins

--- a/docs/deployment/ecs-weave-shippable.md
+++ b/docs/deployment/ecs-weave-shippable.md
@@ -11,12 +11,14 @@ eCommerce application, with fully automated deployments, in 30
 minutes or less.
 
 Your sample application will feature:
+
   * **Amazon ECS**{: style="color: orange"} for container orchestration
   * **Amazon ECR**{: style="color: orange"} for container registry
   * **Weave Scope**{: style="color: orange"} for service discovery and container visualization
   * **Shippable**{: style="color: orange"} for automated CI/CD
 
-This page provides the instructions necessary to:
+This page provides the instructions necessary to:  
+
   * Provision a Weave-enabled Amazon ECS cluster using Cloud Formations and
   deploy all components of the Sock Shop microservices demo application except
   the <a href="https://github.com/microservices-demo/front-end" style="color: orange">front-end</a>
@@ -208,6 +210,7 @@ environment:
       <p></p>
 
     Now, load your Pipeline configuration files into Shippable:
+    
     * Select the `Pipelines` tab, `Resources` view, and then `Add Resource`
     button (far right)
     * In the Subscription Integrations dropdown: choose `Add integration` and

--- a/docs/local-server.sh
+++ b/docs/local-server.sh
@@ -7,3 +7,6 @@ docker run -it --rm \
   -p 127.0.0.1:4000:4000 \
   jekyll/jekyll $@
 
+# # To run with gem github-pages locally
+# bundle exec jekyll build
+# bundle exec jekyll serve


### PR DESCRIPTION
Fixes https://github.com/microservices-demo/microservices-demo/issues/431

* Workaround for docs md page - add blank lines to broken formatted lists
* Add method to build/render Jekyll pages locally using GitHub Pages dependencies (e.g. Kramdown 1.11.1)
