### PR TITLE
Fixing the build

### DIFF
--- a/deploy-doc-tests/lib/find_changes.rb
+++ b/deploy-doc-tests/lib/find_changes.rb
@@ -4,6 +4,7 @@ def find_images_in_k8s_complete_demo
   images = []
   yaml_parts = File.read(REPO_ROOT.join("deploy").join("kubernetes").join("complete-demo.yaml"))\
     .split("---\n")\
+    .select{ |part| part.to_s != "" }
     .map { |part| YAML.load(part) }
 
   yaml_parts \


### PR DESCRIPTION
The deploy doc code for parsing the k8s yaml file chocked on an empty string while splitting on `---`. Added select statement to filter it out.