### PR TITLE
Fix Travis deploy doc build (triggered by cron job)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ deploy:
   acl: public_read
   on:
     branch: master
-  condition: "\"$TRAVIS_EVENT_TYPE\" != \"cron\""
+  condition: "\"$TRAVIS_EVENT_TYPE\" != \"cron\" && -z \"$DEPLOY_DOC\""
 
 notifications:
   slack:


### PR DESCRIPTION
The problem is that somehow the reset value does not get accepted by
Travis. Working around that by checking for the presence of the `$DEPLOY_DOC`
variable.

This closes https://github.com/microservices-demo/microservices-demo/issues/502 with a hack.
