### PR TITLE
Set correct AWS credentials in deploy doc builds spawned by the cronjob

### DIFF
--- a/.travis-cron.rb
+++ b/.travis-cron.rb
@@ -92,7 +92,11 @@ else
         global: [ "SPAWNED_BY_CRON_BUILD=#{cron_build_number}" ],
         matrix: platforms_to_test.map { |platform| "DEPLOY_DOC=#{platform.markdown_file}" }
       },
-      script: ["deploy_doc $DEPLOY_DOC -r"]
+      script: [
+        "export AWS_ACCESS_KEY=$DEPLOY_DOC_AWS_ACCESS_KEY",
+        "export AWS_SECRET_ACCESS_KEY=$DEPLOY_DOC_AWS_SECRET_ACCESS_KEY",
+        "deploy_doc $DEPLOY_DOC -r"
+      ]
     })
   }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ script:
 - set -o pipefail
 - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
     gem install travis-cron_tools;
-    export AWS_ACCESS_KEY=$DEPLOY_DOC_AWS_ACCESS_KEY;
-    export AWS_SECRET_ACCESS_KEY=$DEPLOY_DOC_AWS_SECRET_ACCESS_KEY;
     ruby .travis-cron.rb;
   fi;
 - if [ ! -z "$AWS_ACCESS_KEY" ]; then


### PR DESCRIPTION
I previously overwrote the EC2 credentials in the wrong place, see
https://github.com/microservices-demo/microservices-demo/issues/492#issuecomment-270868951.