### PR TITLE
Overwrite deploy step with a no-op. This makes deploy docs work properly

### DIFF
--- a/.travis-cron.rb
+++ b/.travis-cron.rb
@@ -96,7 +96,13 @@ else
         "export AWS_ACCESS_KEY=$DEPLOY_DOC_AWS_ACCESS_KEY",
         "export AWS_SECRET_ACCESS_KEY=$DEPLOY_DOC_AWS_SECRET_ACCESS_KEY",
         "deploy_doc $DEPLOY_DOC -r"
-      ]
+      ],
+
+      # Overwrite deploy step with a no-op.
+      deploy: {
+        provider: "script",
+        script: "true"
+      }
     })
   }
 


### PR DESCRIPTION
See: https://travis-ci.org/microservices-demo/microservices-demo/builds/189472465 The `docker compose test` completes successfully, the other tests fail for valid reasons.