### PR TITLE
Fix env variable name

### DIFF
--- a/.travis-cron.rb
+++ b/.travis-cron.rb
@@ -93,7 +93,7 @@ else
         matrix: platforms_to_test.map { |platform| "DEPLOY_DOC=#{platform.markdown_file}" }
       },
       script: [
-        "export AWS_ACCESS_KEY=$DEPLOY_DOC_AWS_ACCESS_KEY",
+        "export AWS_ACCESS_KEY_ID=$DEPLOY_DOC_AWS_ACCESS_KEY",
         "export AWS_SECRET_ACCESS_KEY=$DEPLOY_DOC_AWS_SECRET_ACCESS_KEY",
         "deploy_doc $DEPLOY_DOC -r"
       ],


### PR DESCRIPTION
* travis-cron creating the wrong env variable name