### PR TITLE
fix front-end health check on k8s

### DIFF
--- a/deploy/kubernetes/manifests/front-end-dep.yaml
+++ b/deploy/kubernetes/manifests/front-end-dep.yaml
@@ -29,13 +29,13 @@ spec:
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
-            path: /health
+            path: /
             port: 8079
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
-            path: /health
+            path: /
             port: 8079
           initialDelaySeconds: 180
           periodSeconds: 3


### PR DESCRIPTION
The front-end is healthy when it can respond to a request on /, so I changed the health check to reflect that. It was checking the non existent url "/health".