### PR TITLE
Fix k8s manifest name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ install:
 
 script:
 - set -o pipefail
-- gem install travis-cron_tools;
-- ruby .travis-cron.rb;
+- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+    gem install travis-cron_tools;
+    ruby .travis-cron.rb;
+  fi;
 - if [ ! -z "$AWS_ACCESS_KEY" ]; then
     aws cloudformation validate-template --template-body "file:////${PWD}/deploy/aws-ecs/cloudformation.json" | jq . ;
   fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ install:
 
 script:
 - set -o pipefail
-- if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
-    gem install travis-cron_tools;
-    ruby .travis-cron.rb;
-  fi;
+- gem install travis-cron_tools;
+- ruby .travis-cron.rb;
 - if [ ! -z "$AWS_ACCESS_KEY" ]; then
     aws cloudformation validate-template --template-body "file:////${PWD}/deploy/aws-ecs/cloudformation.json" | jq . ;
   fi;


### PR DESCRIPTION
This docs update fixes a manifest name in the deploy doc. File has been renamed previously but the deploy doc instructions were not updated.