### PR TITLE
Align nomad hostnames in Vagrant and documentation

### DIFF
--- a/deploy/nomad/Vagrantfile
+++ b/deploy/nomad/Vagrantfile
@@ -158,13 +158,13 @@ Vagrant.configure(2) do |config|
 
   (1..num_nodes.to_i).each do |n|
     ip = "192.168.59.10#{n}"
-    name = "ci-sockshop-node#{n}"
+    name = "ci-sockshop-nomad-node#{n}"
     nomad_config = <<-EOF
     bind_addr = "#{ip}"
     data_dir = "/var/lib/nomad"
     EOF
 
-    if name == "ci-sockshop-node1"
+    if name == "ci-sockshop-nomad-node1"
       nomad_config << <<-EOF
       server {
         enabled = true
@@ -191,13 +191,12 @@ Vagrant.configure(2) do |config|
       m.vm.network "private_network", ip: ip
 
       m.vm.provider :aws do |aws, override|
+        aws.associate_public_ip = true
         aws.private_ip_address = ip
-        if name != "ci-sockshop-node1"
-          aws.tags = {'Name' => 'ci-sockshop-nomad-node'}
-        end
+        aws.tags = {'Name' => name}
       end
 
-      if name == "ci-sockshop-node1"
+      if name == "ci-sockshop-nomad-node1"
         m.vm.provision "shell", name: "Start consul (bootstrapped)", inline: consul_initial
       else
         m.vm.provision "shell", name: "Start consul (join cluster)", env: {"IP" => ip}, inline: consul_joiner
@@ -210,7 +209,7 @@ Vagrant.configure(2) do |config|
       m.vm.provision "shell", name: "Launch scope", env: {"SCOPE_TOKEN" => ENV["SCOPE_TOKEN"] || ""}, inline: launch_scope
 
       # Stuff only the head node should take care of
-      if name == "ci-sockshop-node1"
+      if name == "ci-sockshop-nomad-node1"
         m.vm.provider "virtualbox" do |vb|
           vb.memory = "1024"
         end


### PR DESCRIPTION
Changed the hostnames in the Vagrant deploy and updated to the latest docs which have matching hostnames in the nomad deploy instructions.

This fixes the deploy_doc test, which was failing before.