### PR TITLE
Increase ecs instances

### DIFF
--- a/deploy/aws-ecs/cloudformation.json
+++ b/deploy/aws-ecs/cloudformation.json
@@ -260,7 +260,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "CartTask"
                 }
@@ -307,7 +307,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "CatalogueTask"
                 }
@@ -370,7 +370,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "UserTask"
                 }
@@ -448,7 +448,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "OrdersTask"
                 }
@@ -478,7 +478,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "PaymentTask"
                 }
@@ -513,7 +513,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "QueueMasterTask"
                 }
@@ -565,7 +565,7 @@
                 "Cluster": {
                     "Ref": "EcsCluster"
                 },
-                "DesiredCount": 1,
+                "DesiredCount": 3,
                 "TaskDefinition": {
                     "Ref": "ShippingTask"
                 }


### PR DESCRIPTION
Increased the non DB services to 3 instances. Tested and everything works as expected. If making requests from multiple browsers and doing the load test, you can see all services in Weave Scope connecting up nicely.