### PR TITLE
Update scripts and docs submodule for mesos deploy docs

### DIFF
--- a/deploy/mesos-cni/mesos-cni.sh
+++ b/deploy/mesos-cni/mesos-cni.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 version="1.0.0"
 
@@ -8,7 +8,7 @@ USER=ubuntu
 MASTERS=($MASTER)
 AGENTS=($SLAVE0 $SLAVE1 $SLAVE2)
 SSH_OPTS=-oStrictHostKeyChecking=no
-SERVICES=("cart-db" "orders-db" "user-db" "shipping" "orders" "catalogue" "catalogue-db" "cart" "payment" "user" "front-end")
+SERVICES=("cart-db" "orders-db" "user-db" "shipping" "orders" "catalogue" "catalogue-db" "cart" "payment" "user" "front-end" "rabbitmq")
 
 
 ############## Begin Utilities ###################
@@ -422,8 +422,9 @@ do_start() {
     launch_service orders-db    "echo ok"                                       mongo                               --no-shell
     launch_service catalogue-db "echo ok"                                       weaveworksdemos/catalogue-db        --no-shell ", \\\"MYSQL_ALLOW_EMPTY_PASSWORD\\\": \\\"true\\\", \\\"MYSQL_DATABASE\\\": \\\"socksdb\\\""
     launch_service user-db      "echo ok"                                       weaveworksdemos/user-db             --no-shell
+    launch_service rabbitmq     "echo ok"                                       rabbitmq:3                          --no-shell
 
-    launch_service shipping     "java -Djava.security.egd=file:/dev/urandom -jar ./app.jar --port=80 --queue.address=rabbitmq.mesos-executeinstance.weave.local"                            weaveworksdemos/shipping    --shell
+    launch_service shipping     "java -Djava.security.egd=file:/dev/urandom -jar ./app.jar --port=80 --spring.rabbitmq.host=rabbitmq.mesos-executeinstance.weave.local"                     weaveworksdemos/shipping    --shell
     launch_service orders       "java -Djava.security.egd=file:/dev/urandom -jar ./app.jar --port=80 --db=orders-db.mesos-executeinstance.weave.local --domain=mesos-executeinstance.weave.local --logging.level.works.weave=DEBUG"    weaveworksdemos/orders   --shell
     launch_service catalogue    "./app -port=80 -DSN=catalogue_user:default_password@tcp\(catalogue-db.mesos-executeinstance.weave.local:3306\)/socksdb"                                    weaveworksdemos/catalogue   --shell
     launch_service cart         "java -Djava.security.egd=file:/dev/urandom -jar ./app.jar --port=80 --db=cart-db.mesos-executeinstance.weave.local --logging.level.works.weave=DEBUG"      weaveworksdemos/cart        --shell

--- a/deploy/mesos-marathon/marathon.json
+++ b/deploy/mesos-marathon/marathon.json
@@ -23,6 +23,24 @@
           }
         },
         {
+          "id": "/weave-demo/database/rabbitmq",
+          "cpus": 0.1,
+          "mem": 1024.0,
+          "container": {
+            "type": "DOCKER",
+            "docker": {
+              "image": "rabbitmq:3",
+              "network": "BRIDGE",
+              "parameters": [
+                {
+                  "key": "hostname",
+                  "value": "rabbitmq.weave.local"
+                }
+              ]
+            }
+          }
+        },
+        {
           "id": "/weave-demo/database/cart-db",
           "cpus": 0.1,
           "mem": 1024.0,
@@ -175,6 +193,25 @@
                   "value": "shipping.weave.local"
                 }
               ]
+            }
+          }
+        },
+        {
+          "id": "/weave-demo/service/queue-master",
+          "cpus": 0.5,
+          "mem": 1024.0,
+          "container": {
+            "type": "DOCKER",
+            "docker": {
+              "image": "weaveworksdemos/queue-master:latest",
+              "network": "BRIDGE",
+              "parameters": [
+                {
+                  "key": "hostname",
+                  "value": "queue-master.weave.local"
+                }
+              ],
+              "privileged": true
             }
           }
         },

--- a/deploy/mesos-marathon/mesos-marathon.sh
+++ b/deploy/mesos-marathon/mesos-marathon.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 version="1.0.0"
 


### PR DESCRIPTION
* Updates docs submodule for mesos deploy docs
* Changed scripts from sh to bash because arrays aren't supported by sh
* Added rabbitmq and queue-master to mesos-marathon
* Added rabbitmq to mesos-cni, didn't add queue-master because no support for priveleged container