### PR TITLE
Update carts, orders and shipping. Add readme info.

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -6,3 +6,7 @@ See the [documentation](https://microservices-demo.github.io/microservices-demo/
 
 There are 2 sets of manifests for deploying Sock Shop on Kubernetes: one in the [manifests directory](manifests/), and complete-demo.yaml. The complete-demo.yaml is a single file manifest
 made by concatenating all the manifests from the manifests directory, so please regenerate it when changing files in the manifests directory.
+
+## Monitoring
+
+All monitoring is performed by prometheus. All services expose a `/metrics` endpoint. All services have a Prometheus Histogram called `request_duration_seconds`, which is automatically appended to create the metrics `_count`, `_sum` and `_bucket`.

--- a/deploy/kubernetes/complete-demo.yaml
+++ b/deploy/kubernetes/complete-demo.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: carts
-        image: weaveworksdemos/carts:0.4.3
+        image: weaveworksdemos/carts:0.4.5
         ports:
          - containerPort: 80
         env:
@@ -106,8 +106,6 @@ metadata:
   name: carts
   labels:
     name: carts
-  annotations:
-    prometheus.io/path: "/prometheus"
   namespace: sock-shop
 spec:
   ports:
@@ -318,7 +316,7 @@ spec:
     spec:
       containers:
       - name: orders
-        image: weaveworksdemos/orders:0.4.3
+        image: weaveworksdemos/orders:0.4.4
         env:
          - name: ZIPKIN
            value: zipkin.zipkin.svc.cluster.local
@@ -347,8 +345,6 @@ metadata:
   name: orders
   labels:
     name: orders
-  annotations:
-    prometheus.io/path: "/prometheus"
   namespace: sock-shop
 spec:
   ports:
@@ -503,7 +499,7 @@ spec:
     spec:
       containers:
       - name: shipping
-        image: weaveworksdemos/shipping:0.4.4
+        image: weaveworksdemos/shipping:0.4.5
         env:
          - name: ZIPKIN
            value: zipkin.zipkin.svc.cluster.local
@@ -533,8 +529,6 @@ metadata:
   name: shipping
   labels:
     name: shipping
-  annotations:
-    prometheus.io/path: "/prometheus"
   namespace: sock-shop
 spec:
   ports:

--- a/deploy/kubernetes/manifests/carts-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: carts
-        image: weaveworksdemos/carts:0.4.3
+        image: weaveworksdemos/carts:0.4.5
         env:
          - name: ZIPKIN
            value: zipkin.zipkin.svc.cluster.local

--- a/deploy/kubernetes/manifests/carts-svc.yml
+++ b/deploy/kubernetes/manifests/carts-svc.yml
@@ -5,8 +5,6 @@ metadata:
   name: carts
   labels:
     name: carts
-  annotations:
-    prometheus.io/path: "/prometheus"
   namespace: sock-shop
 spec:
   ports:

--- a/deploy/kubernetes/manifests/orders-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: orders
-        image: weaveworksdemos/orders:0.4.3
+        image: weaveworksdemos/orders:0.4.4
         env:
          - name: ZIPKIN
            value: zipkin.zipkin.svc.cluster.local

--- a/deploy/kubernetes/manifests/orders-svc.yaml
+++ b/deploy/kubernetes/manifests/orders-svc.yaml
@@ -5,8 +5,6 @@ metadata:
   name: orders
   labels:
     name: orders
-  annotations:
-    prometheus.io/path: "/prometheus"
   namespace: sock-shop
 spec:
   ports:

--- a/deploy/kubernetes/manifests/shipping-dep.yaml
+++ b/deploy/kubernetes/manifests/shipping-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: shipping
-        image: weaveworksdemos/shipping:0.4.4
+        image: weaveworksdemos/shipping:0.4.5
         env:
          - name: ZIPKIN
            value: zipkin.zipkin.svc.cluster.local

--- a/deploy/kubernetes/manifests/shipping-svc.yaml
+++ b/deploy/kubernetes/manifests/shipping-svc.yaml
@@ -5,8 +5,6 @@ metadata:
   name: shipping
   labels:
     name: shipping
-  annotations:
-    prometheus.io/path: "/prometheus"
   namespace: sock-shop
 spec:
   ports:


### PR DESCRIPTION
All services now expose on the `/metrics` endpoint. So the old prometheus annotation could be removed.