### PR TITLE
Fix alert manager config in Docker Compose deployment

### DIFF
--- a/deploy/docker-compose/alertmanager.yml
+++ b/deploy/docker-compose/alertmanager.yml
@@ -21,7 +21,7 @@ receivers:
 - name: 'email-all'
   email_configs:
     # The email address to send notifications to.
-  - to: ''
+  - to: 'alertmanager@example.org'
     # Whether or not to notify about resolved alerts.
     send_resolved: true
     # The HTML body of the email notification.


### PR DESCRIPTION
The "to" field was not populated, making the alertmanager service not to
come up in the monitoring group.

There is no related issue since this is rather a quick fix that I found along the way:
The *alertmanager* service defined in the `docker-compose.yml` file was not being able to come up because of a small misconfiguration.
This commit fixes that.