### PR TITLE
Add ingress yaml for GKE

### DIFF
--- a/deploy/kubernetes/manifests/front-end-ingress.yaml
+++ b/deploy/kubernetes/manifests/front-end-ingress.yaml
@@ -1,0 +1,9 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: front-end-ingress
+  namespace: sock-shop
+spec:
+  backend:
+    serviceName: front-end
+    servicePort: 80


### PR DESCRIPTION
Though there is not yet a tutorial for this, the sock shop cannot run on GKE without this file (and some changes to front-end-svc.yaml
detailed [here](https://docs.google.com/document/d/1gWaM_wd-4kkmsf2j_LHJ8ICrGCgTgcLNf5EFeapDeWg/edit?usp=sharing)).

Adding it would make the install easier and _I don't think_ it would introduce problems with other platforms.