### PR TITLE
Add rolebinding yaml for kubernetes/manifest-monitoring

### DIFF
--- a/deploy/kubernetes/manifests-monitoring/monitoring-rolebinding.yaml
+++ b/deploy/kubernetes/manifests-monitoring/monitoring-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring
+  labels:
+    k8s-app: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: monitoring


### PR DESCRIPTION
Post k8s 1.6, RBAC enforces more strict policy for service account
outside of "kube-system"[1]. Since grafana-import-dashboards Job has an
init-container that need to reach endpoints API, this change will assign
a `view` clusterrole to `default` service account.

[1] https://kubernetes.io//docs/admin/authorization/rbac/#upgrading-from-15

- Read the contribution guidelines
- Include a reference to a related issue in this repository
- A description of the changes proposed in the pull request