### PR TITLE
Fixed autoscaling demo work correctly in the Kubernetes 1.7 API

### DIFF
--- a/deploy/kubernetes/autoscaling/cart-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/cart-hsc.yaml
@@ -1,15 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: cart
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: cart
-    subresource: scale
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50

--- a/deploy/kubernetes/autoscaling/catalogue-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/catalogue-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: catalogue
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: catalogue
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    

--- a/deploy/kubernetes/autoscaling/front-end-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/front-end-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: front-end
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: front-end
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    

--- a/deploy/kubernetes/autoscaling/orders-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/orders-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: orders
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: orders
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    

--- a/deploy/kubernetes/autoscaling/payment-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/payment-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: payment
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: payment
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    

--- a/deploy/kubernetes/autoscaling/queue-master-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/queue-master-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: queue-master
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: queue-master
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    

--- a/deploy/kubernetes/autoscaling/shipping-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/shipping-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: shipping
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: shipping
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    

--- a/deploy/kubernetes/autoscaling/user-hsc.yaml
+++ b/deploy/kubernetes/autoscaling/user-hsc.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: user
   namespace: sock-shop
 spec:
-  scaleRef:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: user
-    subresource: scale
+
   minReplicas: 1
   maxReplicas: 10
-  cpuUtilization:
-    targetPercentage: 50
+  targetCPUUtilizationPercentage: 50
+    


### PR DESCRIPTION
API referenced in the current autoscaling demo (extensions/v1beta1) is no longer valid in Kubernetes 1.7.  This commit updates the files to use the correct API (autoscaling/v1).