### PR TITLE
K8S - Add RBAC to Prometheus

### DIFF
--- a/deploy/kubernetes/manifests-monitoring/prometheus-cr.yml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-cr.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/deploy/kubernetes/manifests-monitoring/prometheus-crb.yml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-crb.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring

--- a/deploy/kubernetes/manifests-monitoring/prometheus-dep.yaml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-dep.yaml
@@ -19,14 +19,15 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccount: prometheus
       containers:
       - name: prometheus
         image: prom/prometheus:v1.5.2
         args:
-          - '-storage.local.retention=360h'
-          - '-storage.local.memory-chunks=1048576'
-          - '-config.file=/etc/prometheus/prometheus.yml'
-          - '-alertmanager.url=http://alertmanager:9093'
+        - '-storage.local.retention=360h'
+        - '-storage.local.memory-chunks=1048576'
+        - '-config.file=/etc/prometheus/prometheus.yml'
+        - '-alertmanager.url=http://alertmanager:9093'
         ports:
         - name: web
           containerPort: 9090

--- a/deploy/kubernetes/manifests-monitoring/prometheus-sa.yml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-sa.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+  labels:
+    app: prometheus


### PR DESCRIPTION
Since Kubernetes 1.8.0 bring RBAC by default, this PR add the cluster role and service account to Prometheus.