### PR TITLE
K8S - Add RBAC to FluentD

### DIFF
--- a/deploy/kubernetes/manifests-logging/fluentd-cr.yml
+++ b/deploy/kubernetes/manifests-logging/fluentd-cr.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/kubernetes/manifests-logging/fluentd-crb.yml
+++ b/deploy/kubernetes/manifests-logging/fluentd-crb.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: kube-system

--- a/deploy/kubernetes/manifests-logging/fluentd-daemon.yml
+++ b/deploy/kubernetes/manifests-logging/fluentd-daemon.yml
@@ -8,24 +8,28 @@ metadata:
     name: fluentd
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: fluentd
   template:
     metadata:
       labels:
         name: fluentd
     spec:
+      serviceAccountName: fluentd
       containers:
        - image: weaveworksdemos/log-server
          name: fluentd
          env:
-            - name: FLUENTD_CONF
-              value: elk.conf
+         - name: FLUENTD_CONF
+           value: elk.conf
          volumeMounts:
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
+         - name: varlibdockercontainers
+           mountPath: /var/lib/docker/containers
+           readOnly: true
       volumes:
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/deploy/kubernetes/manifests-logging/fluentd-sa.yaml
+++ b/deploy/kubernetes/manifests-logging/fluentd-sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: kube-system


### PR DESCRIPTION
Since Kubernetes 1.8.0 bring RBAC by default, this PR add the cluster role and service account to FluentD.