### PR TITLE
Prometheus 2.0 compatibility for docker-compose

### DIFF
--- a/deploy/docker-compose/alert.rules
+++ b/deploy/docker-compose/alert.rules
@@ -1,9 +1,12 @@
 # Alert for high error rate in the Sock Shop.
-ALERT HighErrorRate
-  IF rate(request_duration_seconds_count{status_code="500"}[1m]) > .1
-  FOR 1m
-  LABELS { severity = "email" }
-  ANNOTATIONS {
-    summary = "High HTTP 500 error rates",
-    description = "Rate of HTTP 500 errors per 1 minutes: {{ $value }}",
-  }
+groups:
+- name: Sock Shop
+  rules:
+  - alert: HighErrorRate
+    expr: rate(request_duration_seconds_count{status_code="500"}[1m]) > .1
+    for: 1m
+    labels:
+      severity: email
+    annotations:
+      summary: "High HTTP 500 error rates"
+      description: "Rate of HTTP 500 errors per 1 minutes: {{ $value }}"

--- a/deploy/docker-compose/docker-compose.monitoring.yml
+++ b/deploy/docker-compose/docker-compose.monitoring.yml
@@ -8,9 +8,10 @@ services:
           - ./prometheus.yml:/etc/prometheus/prometheus.yml
           - ./alert.rules:/etc/prometheus/alert.rules
         command:
-          - '-config.file=/etc/prometheus/prometheus.yml'
-          - '-storage.local.path=/prometheus'
-          - '-alertmanager.url=http://alertmanager:9093'
+          - '--config.file=/etc/prometheus/prometheus.yml'
+          - '--storage.tsdb.path=/prometheus'
+          - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+          - '--web.console.templates=/usr/share/prometheus/consoles'
         expose:
           - 9090
         ports:
@@ -24,8 +25,8 @@ services:
         volumes:
           - ./alertmanager.yml:/etc/alertmanager/config.yml
         command:
-          - '-config.file=/etc/alertmanager/config.yml'
-          - '-storage.path=/alertmanager'
+          - '--config.file=/etc/alertmanager/config.yml'
+          - '--storage.path=/alertmanager'
     grafana:
         image: grafana/grafana
         depends_on:

--- a/deploy/docker-compose/prometheus.yml
+++ b/deploy/docker-compose/prometheus.yml
@@ -10,6 +10,10 @@ rule_files:
     - "/etc/prometheus/alert.rules"
 
 alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - alertmanager:9093
 
 scrape_configs:
     - job_name: "frontend"


### PR DESCRIPTION
The prometheus docker-compose config has broken with the release of Prometheus 2.0.

These changes seem to work, but as this is my first use of docker-compose or prometheus they probably aren't quite right.

Someone else will need to tackle the Kubernetes etc changes :)