### PR TITLE
Explicitly configure the port for catalogue to be 80 in kubernetes/manifests

### DIFF
--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -16,6 +16,8 @@ spec:
       containers:
       - name: catalogue
         image: weaveworksdemos/catalogue:0.3.5
+        args:
+        - -port=80
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
In case one was to fork this repository and pass arbitrary arguments without passing `-port=80`, `catalogue` would then suddenly no longer work, as:

- `catalogue` defaults to `8081`: https://github.com/microservices-demo/catalogue/blob/0.3.5/cmd/cataloguesvc/main.go#L44
- the default override in `Dockerfile` would then be lost: https://github.com/microservices-demo/catalogue/blob/0.3.5/docker/catalogue/Dockerfile#L12
- `/health` therefore wouldn't be reachable on `80` (but `8081`)
- Kubernetes therefore wouldn't route traffic to `catalogue`