### PR TITLE
(Kubernetes) Fix broken catalogue-dep.yaml

### DIFF
--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: catalogue
         image: weaveworksdemos/catalogue:0.3.5
+        command: ["/app"]
         args:
         - -port=80
         resources:


### PR DESCRIPTION
[A recent  commit](https://github.com/microservices-demo/microservices-demo/commit/23a7914e204dc77ae5f088001e5cc4045f87f92b) added command line arguments without a command. This caused the pod to enter CrashLoopBackOff with:

`  Warning  Failed                 1m (x5 over 2m)  kubelet, minikube  Error: failed to start container "catalogue": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting containe
r process caused "exec: \"-port=80\": executable file not found in $PATH": unknown
`

I'm adding the command to allow the Docker container to start up.