### PR TITLE
fix mongo host name

### DIFF
--- a/deploy/kubernetes/manifests/user-dep.yaml
+++ b/deploy/kubernetes/manifests/user-dep.yaml
@@ -26,7 +26,7 @@ spec:
         ports:
         - containerPort: 80
         env:
-        - name: MONGO_HOST
+        - name: mongo
           value: user-db:27017
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
health check failing because of incorrect env name

(tested in shy-frog)

@bricef 