### PR TITLE
The link to the minikube documentation is incorrect

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,6 +1,6 @@
 # Installing sock-shop on Kubernetes
 
-See the [documentation](https://microservices-demo.github.io/deployment/kubernetes.html) on how to deploy Sock Shop using Minikube.
+See the [documentation](https://microservices-demo.github.io/deployment/kubernetes-minikube.html) on how to deploy Sock Shop using Minikube.
 
 ## Kubernestes manifests
 


### PR DESCRIPTION
I'm not sure if there should also be a link to the general Kubernetes installation docs that this link replaces. 