### PR TITLE
Fixed Docker Image Tag for Elasticsearch & Kibana

### DIFF
--- a/deploy/docker-compose/docker-compose.logging.yml
+++ b/deploy/docker-compose/docker-compose.logging.yml
@@ -2,10 +2,10 @@ version: '2'
 
 services:
   elasticsearch:
-    image: elasticsearch
+    image: elasticsearch:5
     hostname: elasticsearch
   kibana:
-    image: kibana
+    image: kibana:5
     hostname: kibana
     depends_on:
       - elasticsearch


### PR DESCRIPTION
Hi, thank you for awesome applications 👍

# Read the contribution guidelines

Done.

# A description of the changes proposed in the pull request

Because Elasticsearch & Kibana does not have `latest` tag, `docker-compose up` does not work.

- https://hub.docker.com/_/elasticsearch
- https://hub.docker.com/_/kibana

```sh
$ docker-compose -f deploy/docker-compose/docker-compose.yml -f deploy/docker-compose/docker-compose.logging.yml up -d

(snip)

Pulling elasticsearch (elasticsearch:)...
ERROR: manifest for elasticsearch:latest not found

(snip)

Pulling kibana (kibana:)...
ERROR: manifest for kibana:latest not found
```

So, I fixed image tag.

`elasticsearch:5` & `kibana:5` works good 👍 

![image](https://user-images.githubusercontent.com/1573290/56999238-5d659080-6be9-11e9-860a-ac7ccf2e1b54.png)

# Future

I thinks that Elasticsearch 7 or 6.7.1 & Kibana 7 or 6.7.1 are better.

We need update `microservices-demo/log-server` docker image, because it is depends on `fluent-plugin-elasticsearch` version at microservices-demo/log-server. Could you fix it?

- https://github.com/microservices-demo/log-server

From Elasticserach 6 & 7, HTTP header `Content-Type: application/json` is necessary.

```
2019-04-30 15:33:15 +0000 fluent.warn: {"next_retry":"2019-04-30 15:42:05 +0000","error_class":"Elasticsearch::Transport::Transport::Errors::NotAcceptable","error":"[406] {\"error\":\"Content-Type header [] is not supported\",\"status\":406}","plugin_id":"object:2ac41b0eb5f0","message":"temporarily failed to flush the buffer. next_retry=2019-04-30 15:42:05 +0000 error_class=\"Elasticsearch::Transport::Transport::Errors::NotAcceptable\" error=\"[406] {\\\"error\\\":\\\"Content-Type header [] is not supported\\\",\\\"status\\\":406}\" plugin_id=\"object:2ac41b0eb5f0\""}
```

So, I choice Elasticsearch 5 & Kibana 5 this time.

Thanks 👍 