### PR TITLE
Fix kibana eks bugs

### DIFF
--- a/deploy/kubernetes/manifests-logging/elasticsearch.yml
+++ b/deploy/kubernetes/manifests-logging/elasticsearch.yml
@@ -14,7 +14,7 @@ spec:
         name: elasticsearch
     spec:
       containers:
-       - image: elasticsearch
+       - image: elasticsearch:5
          name: elasticsearch
          ports:
           - name: elasticsearch

--- a/deploy/kubernetes/manifests-logging/kibana.yml
+++ b/deploy/kubernetes/manifests-logging/kibana.yml
@@ -14,7 +14,7 @@ spec:
         name: kibana
     spec:
       containers:
-       - image: kibana
+       - image: kibana:5.0.0
          name: kibana
          ports:
           - name: kibana

--- a/deploy/kubernetes/manifests/session-db-dep.yaml
+++ b/deploy/kubernetes/manifests/session-db-dep.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     name: session-db
   namespace: sock-shop
+  annotations:
+    flux.weave.works/automated: 'true'
 spec:
   replicas: 1
   template:
@@ -24,11 +26,11 @@ spec:
         securityContext:
           capabilities:
             drop:
-              - all
+            - all
             add:
-              - CHOWN
-              - SETGID
-              - SETUID
+            - CHOWN
+            - SETGID
+            - SETUID
           readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/deploy/kubernetes/manifests/session-db-dep.yaml
+++ b/deploy/kubernetes/manifests/session-db-dep.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: session-db
-        image: redis:alpine
+        image: redis:4-alpine
         ports:
         - name: redis
           containerPort: 6379


### PR DESCRIPTION
The kibana and elasticsearch images need a version tag which was missing in the kubernetes manifest files. 
Reproduce the error:
` >> kubectl create -f deploy/kubernetes/manifests-logging/elasticsearch.yml `

After describing pod output:

`  Warning  Failed     5s (x2 over 24s)  kubelet,   Failed to pull image "elasticsearch": rpc error: code = Unknown desc = Error response from daemon: manifest for elasticsearch:latest not found
`
Similar error occurs with kibana image as well.