### PR TITLE
Update manifests for Kubernetes v16

### DIFF
--- a/deploy/kubernetes/manifests/carts-db-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/carts-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/front-end-dep.yaml
+++ b/deploy/kubernetes/manifests/front-end-dep.yaml
@@ -1,11 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: front-end
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: front-end
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/loadtest-dep.yaml
+++ b/deploy/kubernetes/manifests/loadtest-dep.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: loadtest
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: load-test
@@ -13,6 +13,9 @@ metadata:
   namespace: loadtest
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: load-test
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/orders-db-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/orders-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/payment-dep.yaml
+++ b/deploy/kubernetes/manifests/payment-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: payment
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/queue-master-dep.yaml
+++ b/deploy/kubernetes/manifests/queue-master-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: queue-master
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: queue-master
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/manifests/rabbitmq-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: rabbitmq
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/session-db-dep.yaml
+++ b/deploy/kubernetes/manifests/session-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: session-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: session-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/shipping-dep.yaml
+++ b/deploy/kubernetes/manifests/shipping-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shipping
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: shipping
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/user-db-dep.yaml
+++ b/deploy/kubernetes/manifests/user-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/user-dep.yaml
+++ b/deploy/kubernetes/manifests/user-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user
   template:
     metadata:
       labels:


### PR DESCRIPTION
 Replace deprecated  extensions/v1beta1 Deployment  api with apps/v1 and added the mandatory apps/v1 Deployment selector field
See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
In kubernetes manifests.
Applies to kubernetes clusters 1.16 and above

- Read the contribution guidelines
- Include a reference to a related issue in this repository
- A description of the changes proposed in the pull request