### PR TITLE
Update Kuberntes Manifests

### DIFF
--- a/deploy/kubernetes/autoscaling/grafana-deployment.yaml
+++ b/deploy/kubernetes/autoscaling/grafana-deployment.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-grafana
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: grafana
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/autoscaling/heapster-deployment.yaml
+++ b/deploy/kubernetes/autoscaling/heapster-deployment.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: heapster
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/autoscaling/influxdb-deployment.yaml
+++ b/deploy/kubernetes/autoscaling/influxdb-deployment.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: influxdb
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/complete-demo.yaml
+++ b/deploy/kubernetes/complete-demo.yaml
@@ -1,4 +1,9 @@
-apiVersion: extensions/v1beta1
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sock-shop
+---
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -7,6 +12,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts-db
   template:
     metadata:
       labels:
@@ -52,7 +60,7 @@ spec:
   selector:
     name: carts-db
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts
@@ -61,6 +69,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts
   template:
     metadata:
       labels:
@@ -110,7 +121,7 @@ spec:
   selector:
     name: carts
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue-db
@@ -119,6 +130,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue-db
   template:
     metadata:
       labels:
@@ -153,7 +167,7 @@ spec:
   selector:
     name: catalogue-db
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue
@@ -162,6 +176,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue
   template:
     metadata:
       labels:
@@ -199,13 +216,16 @@ spec:
   selector:
     name: catalogue
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: front-end
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: front-end
   template:
     metadata:
       labels:
@@ -246,7 +266,7 @@ spec:
   selector:
     name: front-end
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-db
@@ -255,6 +275,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders-db
   template:
     metadata:
       labels:
@@ -300,7 +323,7 @@ spec:
   selector:
     name: orders-db
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders
@@ -309,6 +332,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders
   template:
     metadata:
       labels:
@@ -358,7 +384,7 @@ spec:
   selector:
     name: orders
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment
@@ -367,6 +393,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: payment
   template:
     metadata:
       labels:
@@ -404,7 +433,7 @@ spec:
   selector:
     name: payment
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: queue-master
@@ -413,6 +442,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: queue-master
   template:
     metadata:
       labels:
@@ -443,7 +475,7 @@ spec:
   selector:
     name: queue-master
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq
@@ -452,6 +484,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: rabbitmq
   template:
     metadata:
       labels:
@@ -490,7 +525,7 @@ spec:
   selector:
     name: rabbitmq
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shipping
@@ -499,6 +534,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: shipping
   template:
     metadata:
       labels:
@@ -548,7 +586,7 @@ spec:
   selector:
     name: shipping
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-db
@@ -557,6 +595,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user-db
   template:
     metadata:
       labels:
@@ -602,7 +643,7 @@ spec:
   selector:
     name: user-db
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user
@@ -611,6 +652,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/Chart.yaml
+++ b/deploy/kubernetes/helm-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Sock Shop
 name: helm-chart
-version: 0.2.0
+version: 0.3.0

--- a/deploy/kubernetes/helm-chart/templates/cart-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/cart-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -7,6 +7,9 @@ metadata:
     name: carts-db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts
@@ -7,6 +7,9 @@ metadata:
     name: carts
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue-db
@@ -7,6 +7,9 @@ metadata:
     name: catalogue-db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/catalogue-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue
@@ -7,6 +7,9 @@ metadata:
     name: catalogue
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/front-end-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/front-end-dep.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: front-end
 spec:
   replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      name: front-end
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/ingress.yaml
+++ b/deploy/kubernetes/helm-chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: socks-ingress

--- a/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.loadtest.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: load-test
@@ -7,6 +7,9 @@ metadata:
     name: load-test
 spec:
   replicas: {{ .Values.loadtest.replicas }}
+  selector:
+    matchLabels:
+      name: load-test
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/orders-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-db
@@ -7,6 +7,9 @@ metadata:
     name: orders-db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/orders-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders
@@ -7,6 +7,9 @@ metadata:
     name: orders
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment
@@ -7,6 +7,9 @@ metadata:
     name: payment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: payment
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/queue-master-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/queue-master-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: queue-master
@@ -7,6 +7,9 @@ metadata:
     name: queue-master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: queue-master
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/rabbitmq-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq
@@ -7,6 +7,9 @@ metadata:
     name: rabbitmq
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: rabbitmq
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/session-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/session-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: session-db
@@ -7,6 +7,9 @@ metadata:
     name: session-db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: session-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shipping
@@ -7,6 +7,9 @@ metadata:
     name: shipping
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: shipping
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/user-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-db
@@ -7,6 +7,9 @@ metadata:
     name: user-db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/user-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user
@@ -7,6 +7,9 @@ metadata:
     name: user
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.zipkin.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zipkin-cron
@@ -7,6 +7,9 @@ metadata:
     name: zipkin-cron
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: zipkin-cron
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.zipkin.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zipkin
@@ -7,6 +7,9 @@ metadata:
     name: zipkin
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: zipkin
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.zipkin.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zipkin-mysql
@@ -7,6 +7,9 @@ metadata:
     name: zipkin-mysql
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: zipkin-mysql
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-alerting/alertmanager-dep.yaml
+++ b/deploy/kubernetes/manifests-alerting/alertmanager-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alertmanager

--- a/deploy/kubernetes/manifests-jaeger/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests-jaeger/catalogue-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-jaeger/jaeger.yaml
+++ b/deploy/kubernetes/manifests-jaeger/jaeger.yaml
@@ -19,7 +19,7 @@ items:
   kind: Namespace
   metadata:
       name: jaeger
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: jaeger-deployment
@@ -29,6 +29,10 @@ items:
       jaeger-infra: jaeger-deployment
   spec:
     replicas: 1
+    selector:
+      matchLabels:
+        app: jaeger
+        jaeger-infra: jaeger-pod
     strategy:
       type: Recreate
     template:

--- a/deploy/kubernetes/manifests-jaeger/payment-dep.yaml
+++ b/deploy/kubernetes/manifests-jaeger/payment-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: payment
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-jaeger/user-dep.yaml
+++ b/deploy/kubernetes/manifests-jaeger/user-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-logging/elasticsearch.yml
+++ b/deploy/kubernetes/manifests-logging/elasticsearch.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: elasticsearch
@@ -8,6 +8,9 @@ metadata:
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: elasticsearch
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-logging/fluentd-daemon.yml
+++ b/deploy/kubernetes/manifests-logging/fluentd-daemon.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd

--- a/deploy/kubernetes/manifests-logging/kibana.yml
+++ b/deploy/kubernetes/manifests-logging/kibana.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana
@@ -8,6 +8,9 @@ metadata:
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: kibana
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-monitoring/grafana-dep.yaml
+++ b/deploy/kubernetes/manifests-monitoring/grafana-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-core
@@ -8,6 +8,10 @@ metadata:
     component: core
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      component: core
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-monitoring/prometheus-dep.yaml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-deployment

--- a/deploy/kubernetes/manifests-monitoring/prometheus-exporter-disk-usage-ds.yaml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-exporter-disk-usage-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-directory-size-metrics

--- a/deploy/kubernetes/manifests-monitoring/prometheus-exporter-kube-state-dep.yaml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-exporter-kube-state-dep.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics-deployment
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests-policy/netpol-cart-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-cart-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: cart-access

--- a/deploy/kubernetes/manifests-policy/netpol-cart-db-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-cart-db-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: carts-db-access

--- a/deploy/kubernetes/manifests-policy/netpol-catalogue-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-catalogue-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: catalogue-access

--- a/deploy/kubernetes/manifests-policy/netpol-catalogue-db-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-catalogue-db-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: catalogue-db-access

--- a/deploy/kubernetes/manifests-policy/netpol-cortex-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-cortex-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: cortex-access

--- a/deploy/kubernetes/manifests-policy/netpol-frontend-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-frontend-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: front-end-access

--- a/deploy/kubernetes/manifests-policy/netpol-orders-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-orders-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: orders-access

--- a/deploy/kubernetes/manifests-policy/netpol-orders-db-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-orders-db-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: orders-db-access

--- a/deploy/kubernetes/manifests-policy/netpol-payment-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-payment-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: payment-access

--- a/deploy/kubernetes/manifests-policy/netpol-rabbitmq-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-rabbitmq-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: rabbitmq-access

--- a/deploy/kubernetes/manifests-policy/netpol-shipping-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-shipping-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: shipping-access

--- a/deploy/kubernetes/manifests-policy/netpol-user-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-user-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: user-access

--- a/deploy/kubernetes/manifests-policy/netpol-user-db-access.yaml
+++ b/deploy/kubernetes/manifests-policy/netpol-user-db-access.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: user-db-access

--- a/deploy/kubernetes/manifests/carts-db-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/carts-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/front-end-dep.yaml
+++ b/deploy/kubernetes/manifests/front-end-dep.yaml
@@ -1,11 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: front-end
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: front-end
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/loadtest-dep.yaml
+++ b/deploy/kubernetes/manifests/loadtest-dep.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: loadtest
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: load-test
@@ -13,6 +13,9 @@ metadata:
   namespace: loadtest
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      name: load-test
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/orders-db-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/orders-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/payment-dep.yaml
+++ b/deploy/kubernetes/manifests/payment-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: payment
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/queue-master-dep.yaml
+++ b/deploy/kubernetes/manifests/queue-master-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: queue-master
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: queue-master
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/manifests/rabbitmq-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: rabbitmq
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/session-db-dep.yaml
+++ b/deploy/kubernetes/manifests/session-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: session-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: session-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/shipping-dep.yaml
+++ b/deploy/kubernetes/manifests/shipping-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shipping
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: shipping
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/user-db-dep.yaml
+++ b/deploy/kubernetes/manifests/user-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/user-dep.yaml
+++ b/deploy/kubernetes/manifests/user-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user
   template:
     metadata:
       labels:


### PR DESCRIPTION
Since all the resources in the complete demo yaml are namespaced it
makes sense to also create the namespace itself.
* Added namespace to `complete-demo.yaml`

Updated all manifests and Helm chart to use updated APIs.
* Deployments updated to use `apps/v1`
* Added selector to all Deployments
* DaemonSets upadted to use `apps/v1`
* Ingresses updated to use `networking.k8s.io/v1beta1`
* NetworkPolicies updated to use `networking.k8s.io/v1`

Updated the Helm chart version since the resources were updated.
* Bump Helm chart version to 0.3.0

This will work on k8s 1.14 and above, where the Ingress resource would
break in 1.13 and less, where it is still under `extensions/v1beta1`

- Read the contribution guidelines
- Include a reference to a related issue in this repository
- A description of the changes proposed in the pull request