### PR TITLE
Nokia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
 - docker
 jdk:
-- oraclejdk8
+- oraclejdk9
 env:
   global:
   - PATH="${PATH}:${HOME}/.local/bin"

--- a/deploy/kubernetes/helm-chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/helm-chart/templates/_helpers.tpl
@@ -14,3 +14,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "catalogueContainerPort" }}8080{{ end -}}
+{{- define "paymentContainerPort" }}8080{{ end -}}
+{{- define "userContainerPort" }}8080{{ end -}}
+{{- define "ordersContainerPort" }}8080{{ end -}}
+{{- define "shippingContainerPort" }}8080{{ end -}}
+{{- define "cartsContainerPort" }}8080{{ end -}}

--- a/deploy/kubernetes/helm-chart/templates/cart-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/cart-db-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: carts-db
-        image: mongo
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.cartsdb.image.repo }}:{{ .Values.cartsdb.image.tag }}
         ports:
         - name: mongo
           containerPort: 27017

--- a/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
@@ -13,8 +13,13 @@ spec:
         name: carts
     spec:
       containers:
-      - name: carts
-        image: weaveworksdemos/carts:0.4.8
+      - command:
+        - /usr/local/bin/java.sh
+        - -jar
+        - ./app.jar
+        - --port={{ template "cartsContainerPort" . }}
+        name: carts
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.carts.image.repo }}:{{ .Values.carts.image.tag }}
         env:
          {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
@@ -30,15 +35,10 @@ spec:
             cpu: 300m
             memory: 2000Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ template "cartsContainerPort" . }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
-          capabilities:
-            drop:
-              - all
-            add:
-              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
@@ -46,14 +46,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 300
+            port: {{ template "cartsContainerPort" . }}
+          initialDelaySeconds: 420
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 180
+            port: {{ template "cartsContainerPort" . }}
+          initialDelaySeconds: 360
           periodSeconds: 3
       volumes:
         - name: tmp-volume

--- a/deploy/kubernetes/helm-chart/templates/carts-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/carts-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ template "cartsContainerPort" . }}
   selector:
     name: carts

--- a/deploy/kubernetes/helm-chart/templates/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-db-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: catalogue-db
-        image: weaveworksdemos/catalogue-db:0.3.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.cataloguedb.image.repo }}:{{ .Values.cataloguedb.image.tag }}
         env:
           - name: MYSQL_ROOT_PASSWORD
             value: fake_password

--- a/deploy/kubernetes/helm-chart/templates/catalogue-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: catalogue
-        image: weaveworksdemos/catalogue:0.3.5
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.catalogue.image.repo }}:{{ .Values.catalogue.image.tag }}
         {{- if .Values.zipkin.enabled }}
         env:
          - name: ZIPKIN
@@ -28,25 +28,20 @@ spec:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ template "catalogueContainerPort" . }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
-          capabilities:
-            drop:
-              - all
-            add:
-              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "catalogueContainerPort" . }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "catalogueContainerPort" . }}
           initialDelaySeconds: 180
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/catalogue-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ template "catalogueContainerPort" . }}
   selector:
     name: catalogue

--- a/deploy/kubernetes/helm-chart/templates/front-end-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/front-end-dep.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: front-end
-        image: weaveworksdemos/front-end:0.3.12
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.frontend.image.repo }}:{{ .Values.frontend.image.tag }}
         resources:
           limits:
             cpu: 300m

--- a/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: load-test
-        image: weaveworksdemos/load-test
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.loadtest.image.repo }}:{{ .Values.loadtest.image.tag }}
         command: ["/bin/sh"]
         args: ["-c", "while true; do locust --host http://front-end.sock-shop.svc.cluster.local -f /config/locustfile.py --clients 5 --hatch-rate 5 --num-request 100 --no-web; done"]
 {{- end }}

--- a/deploy/kubernetes/helm-chart/templates/orders-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-db-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: orders-db
-        image: mongo
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.ordersdb.image.repo }}:{{ .Values.ordersdb.image.tag }}
         ports:
         - name: mongo
           containerPort: 27017

--- a/deploy/kubernetes/helm-chart/templates/orders-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-dep.yaml
@@ -14,7 +14,12 @@ spec:
     spec:
       containers:
       - name: orders
-        image: weaveworksdemos/orders:0.4.7
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.orders.image.repo }}:{{ .Values.orders.image.tag }}
+        command:
+        - /usr/local/bin/java.sh
+        - -jar
+        - ./app.jar
+        - --port={{ template "ordersContainerPort" . }}
         env:
          {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
@@ -30,15 +35,10 @@ spec:
             cpu: 200m
             memory: 2000Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ template "ordersContainerPort" . }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
-          capabilities:
-            drop:
-              - all
-            add:
-              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
@@ -46,17 +46,16 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "ordersContainerPort" . }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "ordersContainerPort" . }}
           initialDelaySeconds: 180
           periodSeconds: 3
       volumes:
         - name: tmp-volume
           emptyDir:
             medium: Memory
-

--- a/deploy/kubernetes/helm-chart/templates/orders-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ template "ordersContainerPort" . }}
   selector:
     name: orders

--- a/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
@@ -14,7 +14,10 @@ spec:
     spec:
       containers:
       - name: payment
-        image: weaveworksdemos/payment:0.4.3
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.payment.image.repo }}:{{ .Values.payment.image.tag }}
+        command:
+        - /app
+        - -decline={{ .Values.payment.declinePaymentsOverAmount }}
         resources:
           limits:
             cpu: 100m
@@ -23,7 +26,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ template "paymentContainerPort" . }}
         {{- if .Values.zipkin.enabled }}
         env:
         - name: ZIPKIN
@@ -32,21 +35,16 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
-          capabilities:
-            drop:
-              - all
-            add:
-              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "paymentContainerPort" . }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "paymentContainerPort" . }}
           initialDelaySeconds: 180
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/payment-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/payment-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ template "paymentContainerPort" . }}
   selector:
     name: payment

--- a/deploy/kubernetes/helm-chart/templates/queue-master-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/queue-master-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: queue-master
-        image: weaveworksdemos/queue-master:0.3.1
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.queuemaster.image.repo }}:{{ .Values.queuemaster.image.tag }}
         env:
          {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN

--- a/deploy/kubernetes/helm-chart/templates/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/rabbitmq-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq
-        image: rabbitmq:3.6.8
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.rabbitmq.image.repo }}:{{ .Values.rabbitmq.image.tag }}
         ports:
         - containerPort: 5672
         securityContext:

--- a/deploy/kubernetes/helm-chart/templates/session-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/session-db-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: session-db
-        image: redis:alpine
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.sessiondb.image.repo }}:{{ .Values.sessiondb.image.tag }}
         ports:
         - name: redis
           containerPort: 6379

--- a/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
@@ -14,7 +14,12 @@ spec:
     spec:
       containers:
       - name: shipping
-        image: weaveworksdemos/shipping:0.4.8
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.shipping.image.repo }}:{{ .Values.shipping.image.tag }}
+        command:
+        - /usr/local/bin/java.sh
+        - -jar
+        - ./app.jar
+        - --port={{ template "shippingContainerPort" . }}
         env:
         {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
@@ -30,15 +35,10 @@ spec:
             cpu: 300m
             memory: 2000Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ template "shippingContainerPort" . }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
-          capabilities:
-            drop:
-              - all
-            add:
-              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
@@ -46,17 +46,16 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 300
+            port: {{ template "shippingContainerPort" . }}
+          initialDelaySeconds: 420
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 180
+            port: {{ template "shippingContainerPort" . }}
+          initialDelaySeconds: 360
           periodSeconds: 3
       volumes:
         - name: tmp-volume
           emptyDir:
             medium: Memory
-

--- a/deploy/kubernetes/helm-chart/templates/shipping-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/shipping-svc.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ template "shippingContainerPort" . }}
   selector:
     name: shipping
 

--- a/deploy/kubernetes/helm-chart/templates/user-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-db-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: user-db
-        image: weaveworksdemos/user-db:0.3.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.userdb.image.repo }}:{{ .Values.userdb.image.tag }}
 
         ports:
         - name: mongo

--- a/deploy/kubernetes/helm-chart/templates/user-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: user
-        image: weaveworksdemos/user:0.4.4
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.user.image.repo }}:{{ .Values.user.image.tag }}
         resources:
           limits:
             cpu: 300m
@@ -23,7 +23,7 @@ spec:
             cpu: 100m
             memory: 400Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ template "userContainerPort" . }}
         env:
         - name: MONGO_HOST
           value: user-db:27017
@@ -34,21 +34,16 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
-          capabilities:
-            drop:
-              - all
-            add:
-              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "userContainerPort" . }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ template "userContainerPort" . }}
           initialDelaySeconds: 180
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/user-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-svc.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ template "userContainerPort" . }}
   selector:
     name: user
 

--- a/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: zipkin-cron
-        image: openzipkin/zipkin-dependencies:1.4.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}/{{ .Values.zipkincron.image.repo }}:{{ .Values.zipkincron.image.tag }}
         env:
         - name: STORAGE_TYPE
           value: mysql

--- a/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: zipkin-cron
-        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}/{{ .Values.zipkincron.image.repo }}:{{ .Values.zipkincron.image.tag }}
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.zipkincron.image.repo }}:{{ .Values.zipkincron.image.tag }}
         env:
         - name: STORAGE_TYPE
           value: mysql

--- a/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: openzipkin/zipkin
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}/{{ .Values.zipkin.image.repo }}:{{ .Values.zipkin.image.tag }}
         ports:
         - containerPort: 9411
         env:

--- a/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}/{{ .Values.zipkin.image.repo }}:{{ .Values.zipkin.image.tag }}
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.zipkin.image.repo }}:{{ .Values.zipkin.image.tag }}
         ports:
         - containerPort: 9411
         env:

--- a/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: zipkin-mysql
-        image: openzipkin/zipkin-mysql:1.20.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}/{{ .Values.zipkinmysql.image.repo }}:{{ .Values.zipkinmysql.image.tag }}
         ports:
         - name: mysql
           containerPort: 3306

--- a/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: zipkin-mysql
-        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}/{{ .Values.zipkinmysql.image.repo }}:{{ .Values.zipkinmysql.image.tag }}
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.zipkinmysql.image.repo }}:{{ .Values.zipkinmysql.image.tag }}
         ports:
         - name: mysql
           containerPort: 3306

--- a/deploy/kubernetes/helm-chart/values.yaml
+++ b/deploy/kubernetes/helm-chart/values.yaml
@@ -1,13 +1,104 @@
 # Default values for sock-shop.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+    registry: ''
+
 java:
     options: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
-zipkin: 
-    enabled:  false
-    url: zipkin.zipkin.svc.cluster.local
+
+cartsdb:
+    image:
+        repo: mongo
+        tag: 4.4.0
+
+carts:
+    image:
+        repo: weaveworksdemos/carts
+        tag: 0.4.8
+
+cataloguedb:
+    image:
+        repo: weaveworksdemos/catalogue-db
+        tag: 0.3.0
+
+catalogue:
+    image:
+        repo: weaveworksdemos/catalogue
+        tag: 0.3.5
+
 frontend:
+    image:
+        repo: weaveworksdemos/front-end
+        tag: 0.3.12
     replicas: 1
+
 loadtest:
+    image:
+        repo: weaveworksdemos/load-test
+        tag: 0.1.1
     replicas: 2
     enabled: false
+
+ordersdb:
+    image:
+        repo: mongo
+        tag: 4.4.0
+
+orders:
+    image:
+        repo: weaveworksdemos/orders
+        tag: 0.4.7
+
+payment:
+    image:
+        repo: weaveworksdemos/payment
+        tag: 0.4.3
+    declinePaymentsOverAmount: 200
+
+queuemaster:
+    image:
+        repo: weaveworksdemos/queue-master
+        tag: 0.3.1
+
+rabbitmq:
+    image:
+        repo: rabbitmq
+        tag: 3.6.8
+
+sessiondb:
+    image:
+        repo: redis
+        tag: alpine
+
+shipping:
+    image:
+        repo: weaveworksdemos/shipping
+        tag: 0.4.8
+
+userdb:
+    image:
+        repo: weaveworksdemos/user-db
+        tag: 0.3.0
+
+user:
+    image:
+        repo: weaveworksdemos/user
+        tag: 0.4.4
+
+zipkincron:
+    image:
+        repo: openzipkin/zipkin-dependencies
+        tag: 1.4.0
+
+zipkin:
+    image:
+        repo: openzipkin/zipkin
+        tag: 2.21
+    enabled:  false
+    url: zipkin.zipkin.svc.cluster.local
+
+zipkinmysql:
+    image:
+        repo: openzipkin/zipkin-mysql
+        tag: 1.20.0


### PR DESCRIPTION
My task was to run your Helm chart on K8s cluster with restrictive pod security policy. The worst problem I encountered was that you grant Linux capabilities in order to bind 80 port inside of container. As a result I was not able to run these images in any way without rebuilding them reverting this operation. That's why I propose you to use other port inside of containers and map it externally to 80 during running a container.
My second issue I resolve with this commit is introducing support of custom Docker registry. On my environment I do not have direct Internet access and need to prefix images with registry address to be able to download them.
I also increased initial delay values for probes at 2 deployments because on my environment these pods need more time to got up and too early starting checking readiness caused with continuosly restarting these pods.