### PR TITLE
Resolve error from DaemonSet lacking selector

### DIFF
--- a/deploy/kubernetes/manifests-monitoring/prometheus-exporter-disk-usage-ds.yaml
+++ b/deploy/kubernetes/manifests-monitoring/prometheus-exporter-disk-usage-ds.yaml
@@ -11,6 +11,9 @@ metadata:
       These are scheduled on every node in the Kubernetes cluster.
       To choose directories from the node to check, just mount them on the `read-du` container below `/mnt`.
 spec:
+  selector:
+    matchLabels:
+      app: node-directory-size-metrics
   template:
     metadata:
       labels:


### PR DESCRIPTION
Hi. We were trying to deploy `manifests-monitoring` onto our K8s using https://github.com/vmware-tanzu/carvel-kapp and encountered the following error. This change seems to fix it.

```
Error: Applying create daemonset/node-directory-size-metrics (apps/v1) namespace: monitoring:
  Creating resource daemonset/node-directory-size-metrics (apps/v1) namespace: monitoring:
    DaemonSet.apps "node-directory-size-metrics" is invalid: spec.template.metadata.labels:
      Invalid value: map[string]string{"app":"node-directory-size-metrics", "kapp.k14s.io/app":"1619703669090365199", "kapp.k14s.io/association":"v1.66a6fe7f6eee440e50546c22bdc097c4"}: `selector` does not match template `labels` (reason: Invalid)
```