### PR TITLE
Avoid granting Linux capabilities

### DIFF
--- a/deploy/kubernetes/helm-chart/templates/cart-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/cart-db-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: carts-db
-        image: mongo
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.cartsdb.image.repo }}:{{ .Values.cartsdb.image.tag }}
         ports:
         - name: mongo
           containerPort: 27017

--- a/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/carts-dep.yaml
@@ -16,8 +16,13 @@ spec:
         name: carts
     spec:
       containers:
-      - name: carts
-        image: weaveworksdemos/carts:0.4.8
+      - command:
+        - /usr/local/bin/java.sh
+        - -jar
+        - ./app.jar
+        - --port={{ .Values.carts.containerPort }}
+        name: carts
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.carts.image.repo }}:{{ .Values.carts.image.tag }}
         env:
          {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
@@ -33,15 +38,17 @@ spec:
             cpu: 300m
             memory: 2000Mi
         ports:
-        - containerPort: 80
+         - containerPort: {{ .Values.carts.containerPort }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
+{{- if lt (int .Values.carts.containerPort) 1024 }}
           capabilities:
             drop:
               - all
             add:
               - NET_BIND_SERVICE
+{{- end }}
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
@@ -49,14 +56,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 300
+            port: {{ .Values.carts.containerPort }}
+          initialDelaySeconds: 420
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 180
+            port: {{ .Values.carts.containerPort }}
+          initialDelaySeconds: 360
           periodSeconds: 3
       volumes:
         - name: tmp-volume

--- a/deploy/kubernetes/helm-chart/templates/carts-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/carts-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ .Values.carts.containerPort }}
   selector:
     name: carts

--- a/deploy/kubernetes/helm-chart/templates/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-db-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: catalogue-db
-        image: weaveworksdemos/catalogue-db:0.3.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.cataloguedb.image.repo }}:{{ .Values.cataloguedb.image.tag }}
         env:
           - name: MYSQL_ROOT_PASSWORD
             value: fake_password

--- a/deploy/kubernetes/helm-chart/templates/catalogue-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-dep.yaml
@@ -17,7 +17,11 @@ spec:
     spec:
       containers:
       - name: catalogue
-        image: weaveworksdemos/catalogue:0.3.5
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.catalogue.image.repo }}:{{ .Values.catalogue.image.tag }}
+        command: ["/app"]
+        args:
+        - -port={{ .Values.catalogue.containerPort }}
+        - -DSN=catalogue_user:default_password@tcp(catalogue-db.{{ .Release.Namespace }}.svc.cluster.local:3306)/socksdb
         {{- if .Values.zipkin.enabled }}
         env:
          - name: ZIPKIN
@@ -31,25 +35,27 @@ spec:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ .Values.catalogue.containerPort }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
+{{- if lt (int .Values.carts.containerPort) 1024 }}
           capabilities:
             drop:
               - all
             add:
               - NET_BIND_SERVICE
+{{- end }}
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.catalogue.containerPort }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.catalogue.containerPort }}
           initialDelaySeconds: 180
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/catalogue-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/catalogue-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ .Values.catalogue.containerPort }}
   selector:
     name: catalogue

--- a/deploy/kubernetes/helm-chart/templates/front-end-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/front-end-dep.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: front-end
-        image: weaveworksdemos/front-end:0.3.12
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.frontend.image.repo }}:{{ .Values.frontend.image.tag }}
         resources:
           limits:
             cpu: 300m

--- a/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/loadtest-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: load-test
-        image: weaveworksdemos/load-test
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.loadtest.image.repo }}:{{ .Values.loadtest.image.tag }}
         command: ["/bin/sh"]
         args: ["-c", "while true; do locust --host http://front-end.sock-shop.svc.cluster.local -f /config/locustfile.py --clients 5 --hatch-rate 5 --num-request 100 --no-web; done"]
 {{- end }}

--- a/deploy/kubernetes/helm-chart/templates/orders-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-db-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: orders-db
-        image: mongo
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.ordersdb.image.repo }}:{{ .Values.ordersdb.image.tag }}
         ports:
         - name: mongo
           containerPort: 27017

--- a/deploy/kubernetes/helm-chart/templates/orders-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-dep.yaml
@@ -17,7 +17,12 @@ spec:
     spec:
       containers:
       - name: orders
-        image: weaveworksdemos/orders:0.4.7
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.orders.image.repo }}:{{ .Values.orders.image.tag }}
+        command:
+        - /usr/local/bin/java.sh
+        - -jar
+        - ./app.jar
+        - --port={{ .Values.orders.containerPort }}
         env:
          {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
@@ -33,15 +38,17 @@ spec:
             cpu: 200m
             memory: 2000Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ .Values.orders.containerPort }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
+{{- if lt (int .Values.orders.containerPort) 1024 }}
           capabilities:
             drop:
               - all
             add:
               - NET_BIND_SERVICE
+{{- end }}
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
@@ -49,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.orders.containerPort }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.orders.containerPort }}
           initialDelaySeconds: 180
           periodSeconds: 3
       volumes:

--- a/deploy/kubernetes/helm-chart/templates/orders-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/orders-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ .Values.orders.containerPort }}
   selector:
     name: orders

--- a/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
@@ -17,7 +17,10 @@ spec:
     spec:
       containers:
       - name: payment
-        image: weaveworksdemos/payment:0.4.3
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.payment.image.repo }}:{{ .Values.payment.image.tag }}
+        command:
+        - /app
+        - -decline={{ .Values.payment.declinePaymentsOverAmount }}
         resources:
           limits:
             cpu: 100m
@@ -26,7 +29,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ .Values.payment.containerPort }}
         {{- if .Values.zipkin.enabled }}
         env:
         - name: ZIPKIN
@@ -35,21 +38,23 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
+{{- if lt (int .Values.payment.containerPort) 1024 }}
           capabilities:
             drop:
               - all
             add:
               - NET_BIND_SERVICE
+{{- end }}
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.payment.containerPort }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.payment.containerPort }}
           initialDelaySeconds: 180
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/payment-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/payment-svc.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ .Values.payment.containerPort }}
   selector:
     name: payment

--- a/deploy/kubernetes/helm-chart/templates/queue-master-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/queue-master-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: queue-master
-        image: weaveworksdemos/queue-master:0.3.1
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.queuemaster.image.repo }}:{{ .Values.queuemaster.image.tag }}
         env:
          {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN

--- a/deploy/kubernetes/helm-chart/templates/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/rabbitmq-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq
-        image: rabbitmq:3.6.8
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.rabbitmq.image.repo }}:{{ .Values.rabbitmq.image.tag }}
         ports:
         - containerPort: 5672
         securityContext:

--- a/deploy/kubernetes/helm-chart/templates/session-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/session-db-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: session-db
-        image: redis:alpine
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.sessiondb.image.repo }}:{{ .Values.sessiondb.image.tag }}
         ports:
         - name: redis
           containerPort: 6379

--- a/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
@@ -17,7 +17,12 @@ spec:
     spec:
       containers:
       - name: shipping
-        image: weaveworksdemos/shipping:0.4.8
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.shipping.image.repo }}:{{ .Values.shipping.image.tag }}
+        command:
+        - /usr/local/bin/java.sh
+        - -jar
+        - ./app.jar
+        - --port={{ .Values.shipping.containerPort }}
         env:
         {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
@@ -33,15 +38,17 @@ spec:
             cpu: 300m
             memory: 2000Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ .Values.shipping.containerPort }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
+{{- if lt (int .Values.shipping.containerPort) 1024 }}
           capabilities:
             drop:
               - all
             add:
               - NET_BIND_SERVICE
+{{- end }}
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
@@ -49,14 +56,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 300
+            port: {{ .Values.shipping.containerPort }}
+          initialDelaySeconds: 420
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
-          initialDelaySeconds: 180
+            port: {{ .Values.shipping.containerPort }}
+          initialDelaySeconds: 360
           periodSeconds: 3
       volumes:
         - name: tmp-volume

--- a/deploy/kubernetes/helm-chart/templates/shipping-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/shipping-svc.yaml
@@ -9,7 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ .Values.shipping.containerPort }}
   selector:
     name: shipping
-

--- a/deploy/kubernetes/helm-chart/templates/user-db-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-db-dep.yaml
@@ -17,8 +17,7 @@ spec:
     spec:
       containers:
       - name: user-db
-        image: weaveworksdemos/user-db:0.3.0
-
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.userdb.image.repo }}:{{ .Values.userdb.image.tag }}
         ports:
         - name: mongo
           containerPort: 27017

--- a/deploy/kubernetes/helm-chart/templates/user-db-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-db-svc.yaml
@@ -12,4 +12,3 @@ spec:
     targetPort: 27017
   selector:
     name: user-db
-

--- a/deploy/kubernetes/helm-chart/templates/user-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-dep.yaml
@@ -17,7 +17,13 @@ spec:
     spec:
       containers:
       - name: user
-        image: weaveworksdemos/user:0.4.4
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.user.image.repo }}:{{ .Values.user.image.tag }}
+        command:
+        - /user
+        args:
+        - -port={{ .Values.user.containerPort }}
+        - -database=mongodb
+        - -mongo-host=user-db.{{ .Release.Namespace }}.svc.cluster.local:27017
         resources:
           limits:
             cpu: 300m
@@ -26,7 +32,7 @@ spec:
             cpu: 100m
             memory: 400Mi
         ports:
-        - containerPort: 80
+        - containerPort: {{ .Values.user.containerPort }}
         env:
         - name: MONGO_HOST
           value: user-db:27017
@@ -37,21 +43,23 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 10001
+{{- if lt (int .Values.user.containerPort) 1024 }}
           capabilities:
             drop:
               - all
             add:
               - NET_BIND_SERVICE
+{{- end }}
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.user.containerPort }}
           initialDelaySeconds: 300
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: {{ .Values.user.containerPort }}
           initialDelaySeconds: 180
           periodSeconds: 3

--- a/deploy/kubernetes/helm-chart/templates/user-svc.yaml
+++ b/deploy/kubernetes/helm-chart/templates/user-svc.yaml
@@ -9,7 +9,6 @@ spec:
   ports:
     # the port that this service should serve on
   - port: 80
-    targetPort: 80
+    targetPort: {{ .Values.user.containerPort }}
   selector:
     name: user
-

--- a/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-cron-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: zipkin-cron
-        image: openzipkin/zipkin-dependencies:1.4.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.zipkincron.image.repo }}:{{ .Values.zipkincron.image.tag }}
         env:
         - name: STORAGE_TYPE
           value: mysql

--- a/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: openzipkin/zipkin
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.zipkin.image.repo }}:{{ .Values.zipkin.image.tag }}
         ports:
         - containerPort: 9411
         env:

--- a/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/zipkin-mysql-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: zipkin-mysql
-        image: openzipkin/zipkin-mysql:1.20.0
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.zipkinmysql.image.repo }}:{{ .Values.zipkinmysql.image.tag }}
         ports:
         - name: mysql
           containerPort: 3306

--- a/deploy/kubernetes/helm-chart/values.yaml
+++ b/deploy/kubernetes/helm-chart/values.yaml
@@ -1,13 +1,111 @@
 # Default values for sock-shop.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+    registry: ''
+
 java:
     options: -Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom
-zipkin: 
-    enabled:  false
-    url: zipkin.zipkin.svc.cluster.local
+
+cartsdb:
+    image:
+        repo: mongo
+        tag: 4.4.0
+
+carts:
+    image:
+        repo: weaveworksdemos/carts
+        tag: 0.4.8
+    containerPort: 80
+
+cataloguedb:
+    image:
+        repo: weaveworksdemos/catalogue-db
+        tag: 0.3.0
+
+catalogue:
+    image:
+        repo: weaveworksdemos/catalogue
+        tag: 0.3.5
+    containerPort: 80
+
 frontend:
     replicas: 1
+    image:
+        repo: weaveworksdemos/front-end
+        tag: 0.3.12
+
 loadtest:
     replicas: 2
     enabled: false
+    image:
+        repo: weaveworksdemos/load-test
+        tag: 0.1.1
+
+ordersdb:
+    image:
+        repo: mongo
+        tag: 4.4.0
+
+orders:
+    image:
+        repo: weaveworksdemos/orders
+        tag: 0.4.7
+    containerPort: 80
+
+payment:
+    image:
+        repo: weaveworksdemos/payment
+        tag: 0.4.3
+    declinePaymentsOverAmount: 200
+    containerPort: 8080
+
+queuemaster:
+    image:
+        repo: weaveworksdemos/queue-master
+        tag: 0.3.1
+
+rabbitmq:
+    image:
+        repo: rabbitmq
+        tag: 3.6.8
+
+sessiondb:
+    image:
+        repo: redis
+        tag: alpine
+
+shipping:
+    image:
+        repo: weaveworksdemos/shipping
+        tag: 0.4.8
+    containerPort: 80
+
+userdb:
+    image:
+        repo: weaveworksdemos/user-db
+        tag: 0.4.0
+
+user:
+    image:
+        repo: weaveworksdemos/user
+        tag: 0.4.7
+    containerPort: 80
+
+zipkincron:
+    image:
+        repo: openzipkin/zipkin-dependencies
+        tag: 1.4.0
+
+zipkin:
+    image:
+        repo: openzipkin/zipkin
+        tag: 2.21
+    enabled:  false
+    url: zipkin.zipkin.svc.cluster.local
+
+zipkinmysql:
+    image:
+        repo: openzipkin/zipkin-mysql
+        tag: 1.20.0
+


### PR DESCRIPTION
My task was to run your Helm chart on K8s cluster with restrictive pod security policy. The worst problem I encountered was that you grant Linux capabilities in order to bind 80 port inside of container. As a result I was not able to run these images in any way without rebuilding them reverting this operation. That's why I propose you to use other port inside of containers and map it externally to 80 during running a container.
My second issue I resolve with this commit is introducing support of custom Docker registry. On my environment I do not have direct Internet access and need to prefix images with registry address to be able to download them.
I also increased initial delay values for probes at 2 deployments because on my environment these pods need more time to got up and too early starting checking readiness caused with continuosly restarting these pods.