### PR TITLE
Change jaeger env

### DIFF
--- a/deploy/kubernetes/manifests-jaeger/jaeger.yaml
+++ b/deploy/kubernetes/manifests-jaeger/jaeger.yaml
@@ -43,8 +43,8 @@ items:
       spec:
           containers:
           -   env:
-              - name: COLLECTOR_ZIPKIN_HTTP_PORT
-                value: "9411"
+              - name: COLLECTOR_ZIPKIN_HOST_PORT
+                value: ":9411"
               image: jaegertracing/all-in-one
               name: jaeger
               ports:


### PR DESCRIPTION
The env COLLECTOR_ZIPKIN_HTTP_PORT is replaced by COLLECTOR_ZIPKIN_HOST_PORT on jaeger:v1.22.0