### PR TITLE
expose the frontend service onto an external IP address

### DIFF
--- a/deploy/kubernetes/complete-demo.yaml
+++ b/deploy/kubernetes/complete-demo.yaml
@@ -318,6 +318,20 @@ spec:
   selector:
     name: front-end
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+  namespace: sock-shop
+spec:
+  type: LoadBalancer
+  selector:
+    name: front-end
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8079
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Now the front end can be accessed at the following IP address
`kubectl get service frontend-external -n sock-shop | awk '{print $4}'`