### PR TITLE
Fix nginx-ingress requirement; the old one is inaccessible

### DIFF
--- a/deploy/kubernetes/helm-chart/requirements.yaml
+++ b/deploy/kubernetes/helm-chart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: nginx-ingress
     version: 0.4.2
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://helm.nginx.com/stable


### PR DESCRIPTION
Resolves: #783 

@errordeveloper  The link to `https://kubernetes-charts.storage.googleapis.com` for `nginx-ingress` in `requirements.yaml` now returns 403. This PR updates the link to: `https://helm.nginx.com/stable` which is accessible.
