### PR TITLE
fix helm ingress to use host value

### DIFF
--- a/deploy/kubernetes/helm-chart/templates/ingress.yaml
+++ b/deploy/kubernetes/helm-chart/templates/ingress.yaml
@@ -17,14 +17,14 @@ spec:
               number: 80
         path: /
         pathType: Prefix
-    {{- if .Values.host }}
-    host: {{ template "host" . }}
+    {{- if .Values.ingress.host }}
+    host: {{ .Values.ingress.host }}
     {{- end }}
   {{- if .Values.ingress.tlsSecretName }}
   tls:
   - secretName: {{ .Values.ingress.tlsSecretName }}
-    {{- if .Values.host }}
+    {{- if .Values.ingress.host }}
     hosts:
-    - {{ template "host" . }}
+    - {{ .Values.ingress.host }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
change helm ingress template to use value instead of template.

## issue
As in the _values.yml_ described a `ingress.host` can be defined:
https://github.com/microservices-demo/microservices-demo/blob/9bffa02d273568b8bddaeaa9e5a3ef6a045b4151/deploy/kubernetes/helm-chart/values.yaml#L13-L17

When changing this value in a custom values file (see following example) it will be ignored.

_`my-values.yml`_
```yaml
ingress:
  host: "sock.shop"
```

## behavior
<details>
  <summary>created ingress object</summary>

```bash
$ helm template sockshop ./deploy/kubernetes/helm-chart --values ./my-values.yml
```

```yaml
# Source: helm-chart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
  labels: {}
  name: sockshop-helm-chart-socks-ingress
spec:
  rules:
    - http:
        paths:
          - backend:
              service:
                name: front-end
                port:
                  number: 80
            path: /
            pathType: Prefix
```

</details>

<details>
  <summary>expected ingress object</summary>

```bash
$ helm template sockshop ./deploy/kubernetes/helm-chart --values ./my-values.yml
```

```yaml
# Source: helm-chart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
  labels: {}
  name: sockshop-helm-chart-socks-ingress
spec:
  rules:
    - http:
        paths:
          - backend:
              service:
                name: front-end
                port:
                  number: 80
            path: /
            pathType: Prefix
      host: sock.shop
```
_expecting `hosts: sock.shop` in last line_
</details>