### PR TITLE
fix grafana configmap not valid

### DIFF
--- a/deploy/kubernetes/manifests-monitoring/20-grafana-configmap.yaml
+++ b/deploy/kubernetes/manifests-monitoring/20-grafana-configmap.yaml
@@ -86,7 +86,7 @@ data:
               "show": false
             },
             "targets": [{
-              "expr": "(time() - process_start_time_seconds{name="prometheus"})",
+              "expr": "(time() - process_start_time_seconds{name='prometheus'})",
               "intervalFactor": 2,
               "refId": "A",
               "step": 4


### PR DESCRIPTION
if someone want to import prometheus-stats-dashboard.json to grafana,he will find it's invalid.
![image](https://user-images.githubusercontent.com/22665221/144007549-699fa308-e6df-44a7-a183-e5a8fb0ed0c4.png)

so the problem is here
```json
"targets": [{
              "expr": "(time() - process_start_time_seconds{name="prometheus"})",
              "intervalFactor": 2,
              "refId": "A",
              "step": 4
            }],
```
 when it changes to be this 
```json
"targets": [{
              "expr": "(time() - process_start_time_seconds{name='prometheus'})",
              "intervalFactor": 2,
              "refId": "A",
              "step": 4
            }],
```
it will be valid