### PR TITLE
fix typo on zipkin.url in helm chart

### DIFF
--- a/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/shipping-dep.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         {{- if .Values.zipkin.enabled }}
          - name: ZIPKIN
-           value: {{ .Values.zipkin.urlj }}
+           value: {{ .Values.zipkin.url }}
         {{- end }}
          - name: JAVA_OPTS
            value: {{ .Values.java.options }}


### PR DESCRIPTION
The helm chart uses a non existing value from `values.yaml`.

This PR will change it to the correct value name.